### PR TITLE
PAPILIO-34-profile-creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [],
   "author": "",
+  "proxy": "http://localhost:1337",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,33 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!<rootDir>/node_modules/",
+      "!src/**/*.stories.{js,jsx,tsx,ts}",
+      "!src/stories/**/*.{js,jsx,ts,tsx}",
+      "!src/reportWebVitals.ts",
+      "!src/index.tsx"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    },
+    "coverageReporters": [
+      "text"
+    ]
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "coverage": "react-scripts test --coverage",
+    "coverage": "react-scripts test --coverage --watchAll=false",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
     "lint": "eslint ./src --fix"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/admin',
-    element: (<LoginPage type='admin' />),
+    element: (<LoginPage type='businessLogic' />),
     errorElement: (<ErrorPage />),
   },
   {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Dashboard from './pages/Dashboard';
 import EmployeeDashboard from './pages/Dashboard/Employees';
+import ProfileDashboard from './pages/Dashboard/Profile';
 import ErrorPage from './pages/Error';
 import LoginPage from './pages/Login';
 
@@ -34,6 +35,10 @@ const router = createBrowserRouter([
       {
         path: 'ads',
         element: <div>Ad center</div>,
+      },
+      {
+        path: 'profile',
+        element: <ProfileDashboard />,
       },
     ],
   },

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -39,7 +39,7 @@ const Button = ({
     'rounded-sm', 'flex', 'cursor-pointer',
     'justify-center', 'w-max', 'box-content', 'items-center',
     {
-      'bg-brand-orange text-white': variant === 'primary',
+      'bg-brand-blue-dark text-white': variant === 'primary',
       'bg-brand-blue text-white': variant === 'secondary',
       [NormalStyle]: variant === 'primary' || variant === 'secondary',
       [OutlineStyle]: variant === 'outline',

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -13,7 +13,10 @@ export enum IconNames {
   EDIT = 'edit',
   DONE = 'done',
   SEARCH = 'search',
-  ADD = 'add'
+  ADD = 'add',
+  FEED = 'feed',
+  EDIT_SQUARE = 'edit_square',
+  SAVE = 'save'
 }
 
 const Icon = ({ size, name }: IconInterface): JSX.Element => {

--- a/src/components/Input/index.stories.tsx
+++ b/src/components/Input/index.stories.tsx
@@ -18,3 +18,9 @@ InputWithLabel.args = {
 
 export const InputNoLabel = Template.bind({});
 InputNoLabel.args = { ...InputWithLabel.args, hasLabel: false };
+
+export const GhostInput = Template.bind({});
+GhostInput.args = {
+  ...InputWithLabel.args,
+  variant: 'ghost',
+};

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 export declare interface InputInterface {
+  ref?: React.MutableRefObject<any>
   label?: string
   hasLabel?: boolean
   placeholder: string
@@ -11,22 +12,32 @@ export declare interface InputInterface {
   testId?: string
   size?: 'sm' | 'md' | 'lg'
   labelPosition?: 'top' | 'left'
+  variant?: 'normal' | 'ghost'
   onChange: (data: React.FormEvent<HTMLInputElement>) => void
 }
 
-const Input = ({ name, value, label, hasLabel = false, placeholder, onChange, type = 'text', testId, size = 'md', labelPosition = 'top' }: InputInterface): JSX.Element => {
-  const className = classNames('flex items-center relative mb-2', {
+const Input = ({ ref, name, value, label, hasLabel = false, placeholder, onChange, type = 'text', testId, size = 'md', labelPosition = 'top', variant = 'normal' }: InputInterface): JSX.Element => {
+  const className = classNames('flex items-center relative', {
+    'mb-2': variant === 'normal',
     'pt-5': hasLabel,
     'pt-2': !hasLabel,
     'justify-end pt-0 mt-3': labelPosition === 'left',
+    'pt-0 flex-1': variant === 'ghost',
   });
 
-  const inputStyle = classNames('border-2 rounded focus:border-gray-400 focus:outline-none placeholder-gray-300', {
+  const normalInputStyle = classNames('border-2 rounded focus:border-gray-400', {
     'px-2 py-1.5 text-sm': size === 'sm',
     'py-2 px-3': size === 'md',
     'py-3 px-3': size === 'lg',
     'w-4/6': labelPosition === 'left',
     'flex-1': labelPosition === 'top',
+  });
+
+  const ghostInputStyle = classNames('w-full bg-transparent');
+
+  const inputStyle = classNames('focus:outline-none placeholder-gray-300', {
+    [normalInputStyle]: variant === 'normal',
+    [ghostInputStyle]: variant === 'ghost',
   });
 
   const labelStyle = classNames({
@@ -38,6 +49,7 @@ const Input = ({ name, value, label, hasLabel = false, placeholder, onChange, ty
     <div className={className} >
       {hasLabel && <label htmlFor={name} className={labelStyle}>{label}</label>}
       <input
+        ref={ref}
         name={name}
         id={name}
         className={inputStyle}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -9,20 +9,38 @@ export declare interface InputInterface {
   value: any
   type?: 'text' | 'password'
   testId?: string
+  size?: 'sm' | 'md' | 'lg'
+  labelPosition?: 'top' | 'left'
   onChange: (data: React.FormEvent<HTMLInputElement>) => void
 }
 
-const Input = ({ name, value, label, hasLabel = false, placeholder, onChange, type = 'text', testId }: InputInterface): JSX.Element => {
-  const className = classNames('flex relative mb-2', {
+const Input = ({ name, value, label, hasLabel = false, placeholder, onChange, type = 'text', testId, size = 'md', labelPosition = 'top' }: InputInterface): JSX.Element => {
+  const className = classNames('flex items-center relative mb-2', {
     'pt-5': hasLabel,
     'pt-2': !hasLabel,
+    'justify-end pt-0 mt-3': labelPosition === 'left',
   });
+
+  const inputStyle = classNames('border-2 rounded focus:border-gray-400 focus:outline-none placeholder-gray-300', {
+    'px-2 py-1.5 text-sm': size === 'sm',
+    'py-2 px-3': size === 'md',
+    'py-3 px-3': size === 'lg',
+    'w-4/6': labelPosition === 'left',
+    'flex-1': labelPosition === 'top',
+  });
+
+  const labelStyle = classNames({
+    'absolute top-0.5 left-0.5 text-sm font-semibold text-gray-600': labelPosition === 'top',
+    'mr-3': labelPosition === 'left',
+  });
+
   return (
     <div className={className} >
-      {hasLabel && <label className="absolute top-0.5 left-0.5 text-sm font-semibold text-gray-600">{label}</label>}
+      {hasLabel && <label htmlFor={name} className={labelStyle}>{label}</label>}
       <input
         name={name}
-        className="border-2 rounded px-3 py-2 flex-1 focus:border-gray-400 focus:outline-none placeholder-gray-300"
+        id={name}
+        className={inputStyle}
         data-testid={testId}
         placeholder={placeholder}
         value={value}

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -9,7 +9,7 @@ export declare interface TabInterface {
   horizontal?: boolean
   to?: LinkProps['to']
   isSelected: boolean
-  icon?: 'ad' | 'home' | 'event' | 'employee'
+  icon?: 'ad' | 'home' | 'event' | 'employee' | 'feed'
   type?: 'button' | 'link'
   testId?: string
 }
@@ -26,6 +26,7 @@ const Tab = ({ label, isSelected, icon, horizontal = false, onClick, type = 'but
     home: IconNames.HOME,
     event: IconNames.EVENT,
     employee: IconNames.EMPLOYEE,
+    feed: IconNames.FEED,
   };
 
   const Content: React.ReactNode = (

--- a/src/features/MultiStepForm/AdminForm/constant.ts
+++ b/src/features/MultiStepForm/AdminForm/constant.ts
@@ -1,0 +1,2 @@
+export const FORM_TITLE =
+  'Who will control the root admin account of your business?';

--- a/src/features/MultiStepForm/AdminForm/index.spec.tsx
+++ b/src/features/MultiStepForm/AdminForm/index.spec.tsx
@@ -1,0 +1,63 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AdminForm, { IFormData } from '.';
+
+const initialState: IFormData = {
+  adminName: '',
+  adminEmail: '',
+  adminPassword: '',
+  role: 'Admin',
+};
+
+describe('profile form test', () => {
+  it('should have 4 inputs', () => {
+    const mockOnSubmit = jest.fn();
+    const mockOnBack = jest.fn();
+    render(<AdminForm initialState={initialState} onSubmit={mockOnSubmit} onBack={mockOnBack}/>);
+
+    const inputs = screen.getAllByRole('textbox');
+
+    expect(inputs.length).toBe(4);
+  });
+
+  it('should accept inputs and send data on submit', async () => {
+    const mockOnSubmit = jest.fn();
+    const mockOnBack = jest.fn();
+    render(<AdminForm initialState={initialState} onSubmit={mockOnSubmit} onBack={mockOnBack}/>);
+
+    userEvent.type(screen.getByRole('textbox', { name: /Name/i }), 'Jonh Doe');
+    userEvent.type(screen.getByRole('textbox', { name: /Email/i }), 'jdoe@email.com');
+    userEvent.type(screen.getByRole('textbox', { name: /Password/i }), 'password');
+    userEvent.click(screen.getByText('Next'));
+
+    expect(mockOnSubmit).toHaveBeenCalledWith(
+      {
+        adminName: 'Jonh Doe',
+        adminEmail: 'jdoe@email.com',
+        adminPassword: 'password',
+        role: 'Admin',
+      }
+    );
+  });
+
+  it('should send inputs value to save when back', async () => {
+    const mockOnSubmit = jest.fn();
+    const mockOnBack = jest.fn();
+    render(<AdminForm initialState={initialState} onSubmit={mockOnSubmit} onBack={mockOnBack}/>);
+
+    userEvent.type(screen.getByRole('textbox', { name: /Name/i }), 'Jonh Doe');
+    userEvent.type(screen.getByRole('textbox', { name: /Email/i }), 'jdoe@email.com');
+    userEvent.type(screen.getByRole('textbox', { name: /Password/i }), 'password');
+    userEvent.click(screen.getByText('Back'));
+
+    expect(mockOnBack).toHaveBeenCalledWith(
+      {
+        adminName: 'Jonh Doe',
+        adminEmail: 'jdoe@email.com',
+        adminPassword: 'password',
+        role: 'Admin',
+      }
+    );
+  });
+});

--- a/src/features/MultiStepForm/AdminForm/index.stories.tsx
+++ b/src/features/MultiStepForm/AdminForm/index.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import AdminForm, { IAdminForm } from '.';
+
+export default {
+  title: 'Features/MultiStepForm/ProfileForm',
+  component: AdminForm,
+} as ComponentMeta<typeof AdminForm>;
+
+const Template: ComponentStory<typeof AdminForm> = (args: IAdminForm) => (
+  <div className='border h-screen flex flex-col justify-center items-center'>
+    <AdminForm {...args}/>
+  </div>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  onSubmit: async () => {},
+};

--- a/src/features/MultiStepForm/AdminForm/index.tsx
+++ b/src/features/MultiStepForm/AdminForm/index.tsx
@@ -1,0 +1,77 @@
+
+import type { InputInterface } from '..';
+import Input from '../../../components/Input';
+import Button from '../../../components/Button';
+import useFormData from '../../../hooks/useFormData';
+import * as constant from './constant';
+
+export declare interface IAdminForm {
+  initialState: IFormData
+  onSubmit: (data: IFormData) => Promise<void>
+  onBack: (data: IFormData) => Promise<void>
+}
+
+export declare interface IFormData {
+  adminName: string
+  adminEmail: string
+  adminPassword: string
+  role: string
+}
+
+const inputs: InputInterface[] = [
+  {
+    name: 'adminName',
+    label: 'Name',
+  },
+  {
+    name: 'adminEmail',
+    label: 'Email',
+  },
+  {
+    name: 'adminPassword',
+    label: 'Password',
+  },
+  {
+    name: 'role',
+    label: 'Role',
+  },
+];
+
+const AdminForm = ({ initialState, onSubmit, onBack }: IAdminForm): JSX.Element => {
+  const [formData, onValueChange, submit] = useFormData<any>({ initialState, onSubmit });
+
+  return (
+    <>
+      <h2 className='text-2xl font-semibold text-brand-blue-dark mb-7'>{constant.FORM_TITLE}</h2>
+      <div className='flex-1'>
+      {inputs.map(({ name, label }) => (
+        <Input
+          key={name}
+          name={name}
+          placeholder=''
+          value={formData[name]}
+          label={label}
+          size='sm'
+          labelPosition='left'
+          onChange={onValueChange}
+          hasLabel
+        />
+      ))}
+      </div>
+      <div className='flex justify-between items-center mt-6'>
+        <Button
+          variant='ghost'
+          text='Back'
+          margin='left'
+          onClick={async () => await onBack(formData)}
+        />
+        <Button
+          text="Next"
+          onClick={submit}
+        />
+      </div>
+    </>
+  );
+};
+
+export default AdminForm;

--- a/src/features/MultiStepForm/ProfileForm/constant.ts
+++ b/src/features/MultiStepForm/ProfileForm/constant.ts
@@ -1,0 +1,2 @@
+export const FORM_TITLE =
+  'Who will control the root admin account of your business ?';

--- a/src/features/MultiStepForm/ProfileForm/constant.ts
+++ b/src/features/MultiStepForm/ProfileForm/constant.ts
@@ -1,2 +1,1 @@
-export const FORM_TITLE =
-  'Who will control the root admin account of your business ?';
+export const FORM_TITLE = 'What information describe your business?';

--- a/src/features/MultiStepForm/ProfileForm/index.spec.tsx
+++ b/src/features/MultiStepForm/ProfileForm/index.spec.tsx
@@ -1,0 +1,50 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ProfilForm, { IFormData } from '.';
+
+const initialState: IFormData = {
+  businessName: '',
+  addressLineOne: '',
+  addressLineTwo: '',
+  postalCode: '',
+  city: '',
+  country: '',
+  province: '',
+};
+
+describe('profile form test', () => {
+  it('should have 7 inputs', async () => {
+    const mockOnSubmit = jest.fn();
+    render(<ProfilForm initialState={initialState} onSubmit={mockOnSubmit}/>);
+
+    const inputs = screen.getAllByRole('textbox');
+
+    expect(inputs.length).toBe(7);
+  });
+
+  it('should accept inputs and send data on submit', async () => {
+    const mockOnSubmit = jest.fn();
+    render(<ProfilForm initialState={initialState} onSubmit={mockOnSubmit} />);
+
+    userEvent.type(screen.getByRole('textbox', { name: /Business name/i }), 'My Awesome Business');
+    userEvent.type(screen.getByRole('textbox', { name: /Address/i }), '1234 Awesome St');
+    userEvent.type(screen.getByRole('textbox', { name: /Postal Code/i }), 'H3B 5G1');
+    userEvent.type(screen.getByRole('textbox', { name: /City/i }), 'Montreal');
+    userEvent.type(screen.getByRole('textbox', { name: /Province/i }), 'QC');
+    userEvent.type(screen.getByRole('textbox', { name: /Country/i }), 'Canada');
+    userEvent.click(screen.getByText('Next'));
+
+    expect(mockOnSubmit).toHaveBeenCalledWith(
+      {
+        businessName: 'My Awesome Business',
+        addressLineOne: '1234 Awesome St',
+        addressLineTwo: '',
+        postalCode: 'H3B 5G1',
+        city: 'Montreal',
+        country: 'Canada',
+        province: 'QC',
+      }
+    );
+  });
+});

--- a/src/features/MultiStepForm/ProfileForm/index.stories.tsx
+++ b/src/features/MultiStepForm/ProfileForm/index.stories.tsx
@@ -16,4 +16,13 @@ const Template: ComponentStory<typeof ProfileForm> = (args: IProfileForm) => (
 export const Basic = Template.bind({});
 Basic.args = {
   onSubmit: async () => {},
+  initialState: {
+    businessName: '',
+    addressLineOne: '',
+    addressLineTwo: '',
+    postalCode: '',
+    city: '',
+    country: '',
+    province: '',
+  },
 };

--- a/src/features/MultiStepForm/ProfileForm/index.stories.tsx
+++ b/src/features/MultiStepForm/ProfileForm/index.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ProfileForm, { IProfileForm } from '.';
+
+export default {
+  title: 'Features/MultiStepForm/ProfileForm',
+  component: ProfileForm,
+} as ComponentMeta<typeof ProfileForm>;
+
+const Template: ComponentStory<typeof ProfileForm> = (args: IProfileForm) => (
+  <div className='border h-screen flex items-center flex-col'>
+    <ProfileForm {...args}/>
+  </div>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  onSubmit: async () => {},
+};

--- a/src/features/MultiStepForm/ProfileForm/index.tsx
+++ b/src/features/MultiStepForm/ProfileForm/index.tsx
@@ -34,16 +34,16 @@ const inputs: InputInterface[] = [
     label: '',
   },
   {
-    name: 'postalCode',
-    label: 'Postal code',
-  },
-  {
     name: 'city',
     label: 'City',
   },
   {
     name: 'province',
     label: 'Province',
+  },
+  {
+    name: 'postalCode',
+    label: 'Postal code',
   },
   {
     name: 'country',

--- a/src/features/MultiStepForm/ProfileForm/index.tsx
+++ b/src/features/MultiStepForm/ProfileForm/index.tsx
@@ -1,0 +1,85 @@
+
+import type { InputInterface } from '..';
+import Input from '../../../components/Input';
+import Button from '../../../components/Button';
+import useFormData from '../../../hooks/useFormData';
+import * as constant from './constant';
+
+export declare interface IProfileForm {
+  initialState: IFormData
+  onSubmit: (data: IFormData) => Promise<void>
+}
+
+export declare interface IFormData {
+  businessName: string
+  addressLineOne: string
+  addressLineTwo: string
+  postalCode: string
+  city: string
+  country: string
+  province: string
+}
+
+const inputs: InputInterface[] = [
+  {
+    name: 'businessName',
+    label: 'Business name',
+  },
+  {
+    name: 'addressLineOne',
+    label: 'Address',
+  },
+  {
+    name: 'addressLineTwo',
+    label: '',
+  },
+  {
+    name: 'postalCode',
+    label: 'Postal code',
+  },
+  {
+    name: 'city',
+    label: 'City',
+  },
+  {
+    name: 'province',
+    label: 'Province',
+  },
+  {
+    name: 'country',
+    label: 'Country',
+  },
+];
+
+const ProfileForm = ({ initialState, onSubmit }: IProfileForm): JSX.Element => {
+  const [formData, onValueChange, submit] = useFormData<any>({ initialState, onSubmit });
+
+  return (
+    <>
+      <h2 className='text-2xl font-semibold text-brand-blue-dark mb-7'>{constant.FORM_TITLE}</h2>
+      <div className='flex-1'>
+      {inputs.map(({ name, label }) => (
+        <Input
+          key={name}
+          name={name}
+          placeholder=''
+          value={formData[name]}
+          label={label}
+          size='sm'
+          labelPosition='left'
+          onChange={onValueChange}
+          hasLabel
+        />
+      ))}
+      </div>
+      <div className='flex justify-end mt-6'>
+        <Button
+          text="Next"
+          onClick={submit}
+        />
+      </div>
+    </>
+  );
+};
+
+export default ProfileForm;

--- a/src/features/MultiStepForm/index.spec.tsx
+++ b/src/features/MultiStepForm/index.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import MultiStepForm, { Progress, Step } from '.';
 import * as AdminConstant from './AdminForm/constant';
 import * as ProfileConstant from './ProfileForm/constant';
@@ -40,7 +41,12 @@ const steps: Step[] = [
 
 describe('multi step form test', () => {
   it('should have the business profile as first page and admin form on the second and validation as last page', () => {
-    render(<MultiStepForm steps={steps} progress={progress} />);
+    const mockOnSubmit = jest.fn();
+    render(
+      <MemoryRouter initialEntries={[{ state: { businessId: 'business1' } }]}>
+        <MultiStepForm steps={steps} progress={progress} onSubmit={mockOnSubmit}/>
+      </MemoryRouter>
+    );
 
     expect(screen.getByText(ProfileConstant.FORM_TITLE)).toBeInTheDocument();
     userEvent.click(screen.getByText('Next'));
@@ -50,7 +56,11 @@ describe('multi step form test', () => {
   });
 
   it('should save the data and display them on back', () => {
-    render(<MultiStepForm steps={steps} progress={progress} />);
+    const mockOnSubmit = jest.fn();
+    render(
+      <MemoryRouter initialEntries={[{ state: { businessId: 'business1' } }]}>
+        <MultiStepForm steps={steps} progress={progress} onSubmit={mockOnSubmit} />
+      </MemoryRouter>);
 
     const name = 'My Awesome Business';
     userEvent.type(screen.getByRole('textbox', { name: 'Business name' }), name);

--- a/src/features/MultiStepForm/index.spec.tsx
+++ b/src/features/MultiStepForm/index.spec.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MultiStepForm, { Progress, Step } from '.';
+import * as AdminConstant from './AdminForm/constant';
+import * as ProfileConstant from './ProfileForm/constant';
+
+const progress: Progress[] = [
+  {
+    icon: 'feed',
+    text: 'Business profile',
+  },
+  {
+    icon: 'admin_panel_settings',
+    text: 'Root accout',
+  },
+  {
+    icon: 'done_all',
+    text: 'Validation',
+  },
+];
+
+const steps: Step[] = [
+  {
+    stepId: 'profile',
+    caption: "Let's create your business profile",
+    last: false,
+  },
+  {
+    stepId: 'adminAccount',
+    caption: "Let's create your main account",
+    last: false,
+  },
+  {
+    stepId: 'validation',
+    // title: 'Your business is being created',
+    caption: "Let's create your business",
+    last: true,
+  },
+];
+
+describe('multi step form test', () => {
+  it('should have the business profile as first page and admin form on the second and validation as last page', () => {
+    render(<MultiStepForm steps={steps} progress={progress} />);
+
+    expect(screen.getByText(ProfileConstant.FORM_TITLE)).toBeInTheDocument();
+    userEvent.click(screen.getByText('Next'));
+    expect(screen.getByText(AdminConstant.FORM_TITLE)).toBeInTheDocument();
+    userEvent.click(screen.getByText('Next'));
+    expect(screen.getByText(/Finish Yeah!!!/)).toBeInTheDocument();
+  });
+
+  it('should save the data and display them on back', () => {
+    render(<MultiStepForm steps={steps} progress={progress} />);
+
+    const name = 'My Awesome Business';
+    userEvent.type(screen.getByRole('textbox', { name: 'Business name' }), name);
+    userEvent.click(screen.getByText('Next'));
+    userEvent.click(screen.getByText('Back'));
+
+    expect(screen.getByDisplayValue(name)).toBeInTheDocument();
+  });
+});

--- a/src/features/MultiStepForm/index.stories.tsx
+++ b/src/features/MultiStepForm/index.stories.tsx
@@ -51,4 +51,5 @@ export const Basic = Template.bind({});
 Basic.args = {
   steps,
   progress,
+  onSubmit: async (): Promise<void> => { console.log('data'); },
 };

--- a/src/features/MultiStepForm/index.stories.tsx
+++ b/src/features/MultiStepForm/index.stories.tsx
@@ -1,0 +1,54 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import MultiStepForm, { IMultiStepForm, Progress, Step } from '.';
+
+export default {
+  title: 'Features/MultiStepForm',
+  component: MultiStepForm,
+} as ComponentMeta<typeof MultiStepForm>;
+
+const Template: ComponentStory<typeof MultiStepForm> = (args: IMultiStepForm) => (
+  <div className='border h-screen flex justify-center items-center'>
+    <MultiStepForm {...args}/>
+  </div>
+);
+
+const progress: Progress[] = [
+  {
+    icon: 'feed',
+    text: 'Business profile',
+  },
+  {
+    icon: 'admin_panel_settings',
+    text: 'Root accout',
+  },
+  {
+    icon: 'done_all',
+    text: 'Validation',
+  },
+];
+
+const steps: Step[] = [
+  {
+    stepId: 'profile',
+    caption: "Let's create your business profile",
+    last: false,
+  },
+  {
+    stepId: 'adminAccount',
+    caption: "Let's create your main account",
+    last: false,
+  },
+  {
+    stepId: 'validation',
+    // title: 'Your business is being created',
+    caption: "Let's create your business",
+    last: true,
+  },
+];
+
+export const Basic = Template.bind({});
+Basic.args = {
+  steps,
+  progress,
+};

--- a/src/features/MultiStepForm/index.tsx
+++ b/src/features/MultiStepForm/index.tsx
@@ -1,13 +1,15 @@
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AdminForm, { IFormData as AdminData } from './AdminForm';
 import ProfileForm, { IFormData as ProfileData } from './ProfileForm';
 
 import Button from '../../components/Button';
+import { useLocation } from 'react-router-dom';
 
 export declare interface IMultiStepForm {
   progress: Progress[]
   steps: Step[]
+  onSubmit: (data: IFormData) => Promise<void>
 }
 
 export declare interface Progress {
@@ -51,11 +53,13 @@ const ProgressBall = ({ icon, text, selected }: IProgressBall): JSX.Element => {
 };
 
 export interface IFormData {
+  businessId: string
   profile: ProfileData
   adminAccount: AdminData
 }
 
 export const initialState: IFormData = {
+  businessId: '',
   profile: {
     businessName: '',
     addressLineOne: '',
@@ -73,10 +77,11 @@ export const initialState: IFormData = {
   },
 };
 
-const MultiStepForm = ({ progress, steps }: IMultiStepForm): JSX.Element => {
+const MultiStepForm = ({ progress, steps, onSubmit }: IMultiStepForm): JSX.Element => {
+  const location = useLocation();
   const [formData, setFormData] = useState(initialState);
   let onStepChange = async (data: any): Promise<void> => { console.log(data); setStep(prev => prev + 1); };
-  const onSubmit = async (): Promise<void> => { console.log('data'); };
+  const submit = async (): Promise<void> => await onSubmit(formData);
   let onBack = async (data: any): Promise<void> => { console.log(data); setStep(prev => prev - 1); };
 
   const [step, setStep] = useState(0);
@@ -100,9 +105,16 @@ const MultiStepForm = ({ progress, steps }: IMultiStepForm): JSX.Element => {
     Body = <AdminForm initialState={formData.adminAccount} onSubmit={onStepChange} onBack={onBack}/>;
   } else {
     Body = <div>Finish Yeah!!!
-      <Button text='submit' onClick={onSubmit} />
+      <Button text='submit' onClick={submit} />
     </div>;
   }
+
+  useEffect(() => {
+    setFormData((prev) => ({
+      ...prev,
+      businessId: location.state.businessId,
+    }));
+  }, []);
 
   return (
     <div className="flex flex-row border border-brand-blue-dark w-4/6">
@@ -121,6 +133,7 @@ const MultiStepForm = ({ progress, steps }: IMultiStepForm): JSX.Element => {
         </div>
       </div>
       <div className='p-9 flex flex-1 flex-col'>
+        {formData.businessId}
         {Body}
       </div>
     </div>

--- a/src/features/MultiStepForm/index.tsx
+++ b/src/features/MultiStepForm/index.tsx
@@ -133,7 +133,6 @@ const MultiStepForm = ({ progress, steps, onSubmit }: IMultiStepForm): JSX.Eleme
         </div>
       </div>
       <div className='p-9 flex flex-1 flex-col'>
-        {formData.businessId}
         {Body}
       </div>
     </div>

--- a/src/features/MultiStepForm/index.tsx
+++ b/src/features/MultiStepForm/index.tsx
@@ -1,0 +1,130 @@
+import classNames from 'classnames';
+import { useState } from 'react';
+import AdminForm, { IFormData as AdminData } from './AdminForm';
+import ProfileForm, { IFormData as ProfileData } from './ProfileForm';
+
+import Button from '../../components/Button';
+
+export declare interface IMultiStepForm {
+  progress: Progress[]
+  steps: Step[]
+}
+
+export declare interface Progress {
+  icon: IProgressBall['icon']
+  text: string
+}
+
+export declare interface Step {
+  stepId: string
+  caption: string
+  last: boolean
+}
+
+export declare interface InputInterface {
+  name: string
+  label: string
+}
+
+declare interface IProgressBall {
+  icon: 'feed' | 'admin_panel_settings' | 'done_all'
+  text: string
+  selected: boolean
+}
+
+const ProgressBall = ({ icon, text, selected }: IProgressBall): JSX.Element => {
+  const style = classNames('material-symbols-outlined whitespace-nowrap bg-white rounded-full p-1.5', {
+    'text-brand-orange-light': selected,
+    'text-brand-blue-dark': !selected,
+  });
+
+  const textStyle = classNames('absolute origin-left left-14 top-1/2 -translate-y-1/2 whitespace-nowrap text-xs', {
+    'text-brand-orange-light': selected,
+    'text-white': !selected,
+  });
+  return (
+    <div className='mb-5 last:mb-0 z-50 relative'>
+      <i className={style}>{icon}</i>
+      <span className={textStyle}>{text}</span>
+    </div>
+  );
+};
+
+export interface IFormData {
+  profile: ProfileData
+  adminAccount: AdminData
+}
+
+export const initialState: IFormData = {
+  profile: {
+    businessName: '',
+    addressLineOne: '',
+    addressLineTwo: '',
+    postalCode: '',
+    city: '',
+    country: '',
+    province: '',
+  },
+  adminAccount: {
+    adminName: '',
+    adminEmail: '',
+    adminPassword: '',
+    role: 'Admin',
+  },
+};
+
+const MultiStepForm = ({ progress, steps }: IMultiStepForm): JSX.Element => {
+  const [formData, setFormData] = useState(initialState);
+  let onStepChange = async (data: any): Promise<void> => { console.log(data); setStep(prev => prev + 1); };
+  const onSubmit = async (): Promise<void> => { console.log('data'); };
+  let onBack = async (data: any): Promise<void> => { console.log(data); setStep(prev => prev - 1); };
+
+  const [step, setStep] = useState(0);
+
+  let Body: JSX.Element;
+  if (steps[step].stepId === 'profile') {
+    onStepChange = async (data) => {
+      setFormData((prev) => ({ ...prev, profile: data }));
+      setStep(prev => prev + 1);
+    };
+    Body = <ProfileForm initialState={formData.profile} onSubmit={onStepChange}/>;
+  } else if (steps[step].stepId === 'adminAccount') {
+    onStepChange = async (data) => {
+      setFormData((prev) => ({ ...prev, adminAccount: data }));
+      setStep(prev => prev + 1);
+    };
+    onBack = async (data) => {
+      setFormData((prev) => ({ ...prev, adminAccount: data }));
+      setStep(prev => prev - 1);
+    };
+    Body = <AdminForm initialState={formData.adminAccount} onSubmit={onStepChange} onBack={onBack}/>;
+  } else {
+    Body = <div>Finish Yeah!!!
+      <Button text='submit' onClick={onSubmit} />
+    </div>;
+  }
+
+  return (
+    <div className="flex flex-row border border-brand-blue-dark w-4/6">
+      <div className="bg-brand-blue-dark px-9 flex flex-col items-center pb-9 overflow-hidden w-64">
+        <div className='-mt-8 bg-brand-blue-dark'>
+          <span className='font-display text-ultra text-brand-blue-light-dark'>{(step + 1)}</span>
+        </div>
+        <h2 className='pt-6 pb-8 text-2xl font-medium text-center leading text-white'>{steps[step].caption}</h2>
+        <div className='w-max flex flex-1 items-center'>
+          <div className='flex flex-col items-center h-max relative pr-28 flex-1'>
+            <span className='bg-white w-0.5 top-0 bottom-0 absolute'></span>
+            {progress.map(({ icon, text }, index) => (
+              <ProgressBall key={text} icon={icon} text={text} selected={step === index}/>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className='p-9 flex flex-1 flex-col'>
+        {Body}
+      </div>
+    </div>
+  );
+};
+
+export default MultiStepForm;

--- a/src/features/SideMenu/index.spec.tsx
+++ b/src/features/SideMenu/index.spec.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import SideMenu from '.';
+
+describe('test side menu', () => {
+  it('should display the 5 tabs', () => {
+    render(
+      <BrowserRouter><SideMenu /></BrowserRouter>
+    );
+
+    const links = screen.getAllByRole('link');
+
+    expect(links).toHaveLength(5);
+  });
+});

--- a/src/features/SideMenu/index.stories.tsx
+++ b/src/features/SideMenu/index.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
 
 import SideMenu from '.';
 
@@ -8,9 +9,11 @@ export default {
 } as ComponentMeta<typeof SideMenu>;
 
 const Template: ComponentStory<typeof SideMenu> = () => (
-  <div className='border h-screen'>
-    <SideMenu />
-  </div>
+  <BrowserRouter>
+    <div className='border h-screen'>
+      <SideMenu />
+    </div>
+  </BrowserRouter>
 );
 
 export const Primary = Template.bind({});

--- a/src/features/SideMenu/index.tsx
+++ b/src/features/SideMenu/index.tsx
@@ -22,6 +22,11 @@ const tabs: ITab[] = [
     icon: 'employee',
     path: 'employees',
   },
+  {
+    label: 'Profile',
+    icon: 'feed',
+    path: 'profile',
+  },
 ];
 
 const SideMenu = (): JSX.Element => {

--- a/src/features/TabList/index.tsx
+++ b/src/features/TabList/index.tsx
@@ -10,7 +10,7 @@ export declare interface TabListInterface {
 
 export declare interface ITab {
   label: string
-  icon?: 'ad' | 'home' | 'event' | 'employee'
+  icon?: 'ad' | 'home' | 'event' | 'employee' | 'feed'
   path?: string
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Merienda:wght@700&display=swap');
+
 html, body, body>div {
   height: 100%;
   width: 100%;

--- a/src/pages/Dashboard/Employees/index.tsx
+++ b/src/pages/Dashboard/Employees/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { sendSignInLinkToEmail } from 'firebase/auth';
 // import axios from 'axios';
 
@@ -12,6 +12,7 @@ import AddForm, { IFormData } from './AddForm';
 import { ITab } from '../../../features/TabList';
 import { IconNames } from '../../../components/Icon';
 import * as constant from './constant';
+import { useParams } from 'react-router-dom';
 
 const tabs: ITab[] = [
   { label: constant.ALL_EMPLOYEES_LABEL },
@@ -29,8 +30,9 @@ const Box = (): JSX.Element => (
 );
 
 const EmployeeDashboard = (): JSX.Element => {
+  const { businessId } = useParams();
+  const [employees, setEmployees] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
-  const businessId = 1234; // TODO: REPLACE THIS WITH A GLOBAL VARIABLE
 
   const onSubmit = async (data: IFormData): Promise<void> => {
     const reqData = {
@@ -40,8 +42,8 @@ const EmployeeDashboard = (): JSX.Element => {
       businessId,
       root: false, // True only while creating the business
     };
-    await fetch('', {
-      method: 'POST', // *GET, POST, PUT, DELETE, etc.
+    await fetch(`/api/business/addEmployee/${businessId ?? ''}`, {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -53,21 +55,20 @@ const EmployeeDashboard = (): JSX.Element => {
         setIsOpen(false);
       });
     });
-    // await axios.post(`business/${businessId}/user`, {
-    //   firebaseId: '',
-    //   email: data.employeeEmail,
-    //   name: data.employeeName,
-    //   businessId,
-    //   root: false, // True only while creating the business
-    // }).then(async () => {
-    //   await sendSignInLinkToEmail(auth, data.employeeEmail, {
-    //     url: 'https://localhost:3000/email-signin',
-    //   });
-    // }).then(() => {
-    //   setIsOpen(false);
-    // });
   };
 
+  useEffect(() => {
+    void (async function getEmployees () {
+      await fetch(`/api/business/get/${businessId ?? ''}/employees`, {
+        method: 'GET',
+      }).then(res => {
+        // @ts-expect-error
+        setEmployees(res.body);
+      });
+    })();
+  }, []);
+
+  console.log(employees);
   return (
     <>
       <PageHeader

--- a/src/pages/Dashboard/Profile/index.spec.tsx
+++ b/src/pages/Dashboard/Profile/index.spec.tsx
@@ -1,0 +1,35 @@
+import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
+import ProfileDashboard from '.';
+import { IconNames } from '../../../components/Icon';
+
+describe('dashboard profile test', () => {
+  it('should display header and have 7 pieces of information', () => {
+    render(<ProfileDashboard />);
+
+    expect(screen.getByText(/Business profile/)).toBeInTheDocument();
+
+    const fields = screen.getAllByTestId('field');
+
+    expect(fields).toHaveLength(7);
+  });
+
+  it('should show inputs when button click', async () => {
+    render(<ProfileDashboard />);
+
+    userEvent.click(screen.getAllByText(IconNames.EDIT_SQUARE)[0]);
+
+    expect(await screen.findAllByRole('textbox')).toHaveLength(1);
+  });
+
+  it('should save new value when save button clicked', async () => {
+    render(<ProfileDashboard />);
+
+    userEvent.click(screen.getAllByText(IconNames.EDIT_SQUARE)[0]);
+    expect(await screen.findAllByRole('textbox')).toHaveLength(1);
+    expect(screen.getAllByTestId('field')).toHaveLength(6);
+    userEvent.click(await screen.findByText(IconNames.SAVE));
+
+    expect(screen.getAllByTestId('field')).toHaveLength(7);
+  });
+});

--- a/src/pages/Dashboard/Profile/index.stories.tsx
+++ b/src/pages/Dashboard/Profile/index.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import ProfileDashboard from './';
+
+export default {
+  title: 'Page/Dashboard/Profile',
+  component: ProfileDashboard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof ProfileDashboard>;
+
+const Template: ComponentStory<typeof ProfileDashboard> = () => <ProfileDashboard />;
+
+export const Basic = Template.bind({});
+Basic.args = {};

--- a/src/pages/Dashboard/Profile/index.tsx
+++ b/src/pages/Dashboard/Profile/index.tsx
@@ -24,9 +24,9 @@ const ProfileDashboard = (): JSX.Element => {
     void (async function getProfile () {
       await fetch(`/api/business/get/${businessId ?? ''}`, {
         method: 'GET',
-      }).then(res => {
-        // @ts-expect-error
-        setProfile(res.body);
+      }).then(() => {
+        // TODO: Setup profile the fetch response
+        setProfile(ProfileInformation);
       });
     })();
   }, []);

--- a/src/pages/Dashboard/Profile/index.tsx
+++ b/src/pages/Dashboard/Profile/index.tsx
@@ -5,8 +5,19 @@ import Button from '../../../components/Button';
 import Input from '../../../components/Input';
 import { IconNames } from '../../../components/Icon';
 import { useParams } from 'react-router-dom';
+import useFormData from '../../../hooks/useFormData';
 
-const ProfileInformation: { [key: string]: string } = {
+declare interface IProfileInformation {
+  'Business name': string
+  Address: string
+  '': string
+  'Postal Code': string
+  City: string
+  Province: string
+  Country: string
+}
+
+const ProfileInformation: IProfileInformation = {
   'Business name': '',
   Address: '',
   '': '',
@@ -39,9 +50,11 @@ const ProfileDashboard = (): JSX.Element => {
       <div className='m-4 flex-1 p-4'>
         {Object.entries(profile).map((entry) => {
           const [isEditing, setIsEditing] = useState(false);
-          const onSubmit = async (): Promise<void> => {
+          const onSubmit = async (data: IProfileInformation): Promise<void> => {
+            setProfile(data);
             setIsEditing(false);
           };
+          const [formData, onValueChange, submit] = useFormData({ initialState: profile, onSubmit });
 
           return (
           <div key={entry[0]} className='flex flex-row items-center mb-2'>
@@ -51,15 +64,16 @@ const ProfileDashboard = (): JSX.Element => {
                 <div className='border rounded-sm border-brand-blue-dark bg-brand-blue-light p-4 flex-1 group flex flex-row items-center justify-between'>
                   <Input
                     name={entry[0]}
-                    value={entry[1]}
+                    // @ts-expect-error
+                    value={formData[entry[0]]}
                     placeholder=''
                     variant='ghost'
-                    onChange={() => {}}
+                    onChange={onValueChange}
                     />
                   <Button
                     variant='ghost'
                     icon={IconNames.SAVE}
-                    onClick={onSubmit}
+                    onClick={submit}
                     hasIcon
                   />
                 </div>

--- a/src/pages/Dashboard/Profile/index.tsx
+++ b/src/pages/Dashboard/Profile/index.tsx
@@ -1,29 +1,47 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import PageHeader from '../../../features/PageHeader';
 import Button from '../../../components/Button';
 import Input from '../../../components/Input';
 import { IconNames } from '../../../components/Icon';
+import { useParams } from 'react-router-dom';
 
 const ProfileInformation: { [key: string]: string } = {
-  'Business name': 'My Awesome Billion Dollar Business ',
-  Address: '1234 Rich St',
-  '': 'App. 2',
-  'Postal Code': 'G6T 3G6',
-  City: 'Montreal',
-  Province: 'QC',
-  Country: 'Canada',
+  'Business name': '',
+  Address: '',
+  '': '',
+  'Postal Code': '',
+  City: '',
+  Province: '',
+  Country: '',
 };
 
 const ProfileDashboard = (): JSX.Element => {
+  const { businessId } = useParams();
+  const [profile, setProfile] = useState(ProfileInformation);
+
+  useEffect(() => {
+    void (async function getProfile () {
+      await fetch(`/api/business/get/${businessId ?? ''}`, {
+        method: 'GET',
+      }).then(res => {
+        // @ts-expect-error
+        setProfile(res.body);
+      });
+    })();
+  }, []);
+
   return (
     <div className='flex flex-col h-full'>
       <PageHeader
         header='Business profile'
       />
       <div className='m-4 flex-1 p-4'>
-        {Object.entries(ProfileInformation).map((entry) => {
+        {Object.entries(profile).map((entry) => {
           const [isEditing, setIsEditing] = useState(false);
+          const onSubmit = async (): Promise<void> => {
+            setIsEditing(false);
+          };
 
           return (
           <div key={entry[0]} className='flex flex-row items-center mb-2'>
@@ -41,7 +59,7 @@ const ProfileDashboard = (): JSX.Element => {
                   <Button
                     variant='ghost'
                     icon={IconNames.SAVE}
-                    onClick={() => { setIsEditing(false); }}
+                    onClick={onSubmit}
                     hasIcon
                   />
                 </div>

--- a/src/pages/Dashboard/Profile/index.tsx
+++ b/src/pages/Dashboard/Profile/index.tsx
@@ -11,9 +11,9 @@ declare interface IProfileInformation {
   'Business name': string
   Address: string
   '': string
-  'Postal Code': string
   City: string
   Province: string
+  'Postal Code': string
   Country: string
 }
 

--- a/src/pages/Dashboard/Profile/index.tsx
+++ b/src/pages/Dashboard/Profile/index.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+
+import PageHeader from '../../../features/PageHeader';
+import Button from '../../../components/Button';
+import Input from '../../../components/Input';
+import { IconNames } from '../../../components/Icon';
+
+const ProfileInformation: { [key: string]: string } = {
+  'Business name': 'My Awesome Billion Dollar Business ',
+  Address: '1234 Rich St',
+  '': 'App. 2',
+  'Postal Code': 'G6T 3G6',
+  City: 'Montreal',
+  Province: 'QC',
+  Country: 'Canada',
+};
+
+const ProfileDashboard = (): JSX.Element => {
+  return (
+    <div className='flex flex-col h-full'>
+      <PageHeader
+        header='Business profile'
+      />
+      <div className='m-4 flex-1 p-4'>
+        {Object.entries(ProfileInformation).map((entry) => {
+          const [isEditing, setIsEditing] = useState(false);
+
+          return (
+          <div key={entry[0]} className='flex flex-row items-center mb-2'>
+            <p className=' font-bold mr-4 w-1/4 text-right'>{entry[0]}</p>
+            {isEditing
+              ? (
+                <div className='border rounded-sm border-brand-blue-dark bg-brand-blue-light p-4 flex-1 group flex flex-row items-center justify-between'>
+                  <Input
+                    name={entry[0]}
+                    value={entry[1]}
+                    placeholder=''
+                    variant='ghost'
+                    onChange={() => {}}
+                    />
+                  <Button
+                    variant='ghost'
+                    icon={IconNames.SAVE}
+                    onClick={() => { setIsEditing(false); }}
+                    hasIcon
+                  />
+                </div>
+                )
+              : (
+                <div className='border rounded-sm p-4 flex-1 group flex flex-row items-center justify-between' data-testid='field' >
+                  <span>{entry[1]}</span>
+                  <div className='text-white group-hover:text-black'>
+                    <Button
+                      variant='ghost'
+                      icon={IconNames.EDIT_SQUARE}
+                      onClick={() => { setIsEditing(true); }}
+                      hasIcon
+                      />
+                  </div>
+                </div>
+                )
+            }
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ProfileDashboard;

--- a/src/pages/Login/index.spec.tsx
+++ b/src/pages/Login/index.spec.tsx
@@ -1,11 +1,12 @@
-// import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-// import * as auth from 'firebase/auth';
 
 import LoginPage from '.';
 import * as businessConstant from './BusinessForm/constant';
+import * as auth from 'firebase/auth';
+import * as ProfileConstant from '../../features/MultiStepForm/ProfileForm/constant';
+import * as AdminConstant from '../../features/MultiStepForm/AdminForm/constant';
 
 jest.mock('firebase/auth');
 
@@ -24,7 +25,7 @@ describe('logic test', () => {
   test('login page business test', async () => {
     // @ts-expect-error
     fetch.mockResolvedValueOnce({
-      status: 201,
+      status: 200,
     });
 
     render(
@@ -43,34 +44,34 @@ describe('logic test', () => {
     expect(fetch).toHaveBeenCalled();
   });
 
-  // test('login page admin test', async () => {
-  //   // @ts-expect-error
-  //   fetch.mockResolvedValueOnce({
-  //     status: 201,
-  //   });
-  //   // @ts-expect-error
-  //   auth.createUserWithEmailAndPassword.mockResolvedValueOnce({
-  //     user: {
-  //       uid: 'firebase-id',
-  //     },
-  //   });
+  test('login page admin test', async () => {
+    // @ts-expect-error
+    fetch.mockResolvedValueOnce({
+      status: 200,
+    });
+    // @ts-expect-error
+    auth.createUserWithEmailAndPassword.mockResolvedValueOnce({
+      user: {
+        uid: 'firebase-id',
+      },
+    });
 
-  //   render(
-  //     <MemoryRouter>
-  //       <Routes>
-  //         <Route path="" element={<LoginPage type='businessLogic' />} />
-  //         {/* // TODO: REMOVE HARD CODED PATH */}
-  //         <Route path="/1234/dashboard" element={<div>DASHBOARD PAGE</div>} />
-  //       </Routes>
-  //     </MemoryRouter>
-  //   );
+    render(
+      <MemoryRouter initialEntries={[{ state: { businessId: '1234' } }]}>
+        <Routes>
+          <Route path="" element={<LoginPage type='businessLogic' />} />
+          <Route path="/1234/dashboard" element={<div>DASHBOARD PAGE</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
 
-  //   expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
-
-  //   expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
-  //   userEvent.click(screen.getByText(adminConstant.SUBMIT_BUTTON_TEXT));
-
-  //   expect(auth.createUserWithEmailAndPassword).toHaveBeenCalled();
-  //   expect(await screen.findByText(/DASHBOARD PAGE/)).toBeInTheDocument();
-  // });
+    expect(screen.getByRole('heading', { name: ProfileConstant.FORM_TITLE })).toBeInTheDocument();
+    userEvent.click(screen.getByText(/Next/));
+    expect(await screen.findByRole('heading', { name: AdminConstant.FORM_TITLE })).toBeInTheDocument();
+    userEvent.click(await screen.findByText(/Next/));
+    expect(await screen.findByText(/submit/)).toBeInTheDocument();
+    userEvent.click(await screen.findByText(/submit/));
+    expect(auth.createUserWithEmailAndPassword).toHaveBeenCalled();
+    expect(await screen.findByText(/DASHBOARD PAGE/)).toBeInTheDocument();
+  });
 });

--- a/src/pages/Login/index.spec.tsx
+++ b/src/pages/Login/index.spec.tsx
@@ -2,11 +2,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import * as auth from 'firebase/auth';
+// import * as auth from 'firebase/auth';
 
 import LoginPage from '.';
 import * as businessConstant from './BusinessForm/constant';
-import * as adminConstant from './AdminForm/constant';
 
 jest.mock('firebase/auth');
 
@@ -44,34 +43,34 @@ describe('logic test', () => {
     expect(fetch).toHaveBeenCalled();
   });
 
-  test('login page admin test', async () => {
-    // @ts-expect-error
-    fetch.mockResolvedValueOnce({
-      status: 201,
-    });
-    // @ts-expect-error
-    auth.createUserWithEmailAndPassword.mockResolvedValueOnce({
-      user: {
-        uid: 'firebase-id',
-      },
-    });
+  // test('login page admin test', async () => {
+  //   // @ts-expect-error
+  //   fetch.mockResolvedValueOnce({
+  //     status: 201,
+  //   });
+  //   // @ts-expect-error
+  //   auth.createUserWithEmailAndPassword.mockResolvedValueOnce({
+  //     user: {
+  //       uid: 'firebase-id',
+  //     },
+  //   });
 
-    render(
-      <MemoryRouter>
-        <Routes>
-          <Route path="" element={<LoginPage type='admin' />} />
-          {/* // TODO: REMOVE HARD CODED PATH */}
-          <Route path="/1234/dashboard" element={<div>DASHBOARD PAGE</div>} />
-        </Routes>
-      </MemoryRouter>
-    );
+  //   render(
+  //     <MemoryRouter>
+  //       <Routes>
+  //         <Route path="" element={<LoginPage type='businessLogic' />} />
+  //         {/* // TODO: REMOVE HARD CODED PATH */}
+  //         <Route path="/1234/dashboard" element={<div>DASHBOARD PAGE</div>} />
+  //       </Routes>
+  //     </MemoryRouter>
+  //   );
 
-    expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
+  //   expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
 
-    expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
-    userEvent.click(screen.getByText(adminConstant.SUBMIT_BUTTON_TEXT));
+  //   expect(screen.getByText(adminConstant.FORM_HEADING)).toBeInTheDocument();
+  //   userEvent.click(screen.getByText(adminConstant.SUBMIT_BUTTON_TEXT));
 
-    expect(auth.createUserWithEmailAndPassword).toHaveBeenCalled();
-    expect(await screen.findByText(/DASHBOARD PAGE/)).toBeInTheDocument();
-  });
+  //   expect(auth.createUserWithEmailAndPassword).toHaveBeenCalled();
+  //   expect(await screen.findByText(/DASHBOARD PAGE/)).toBeInTheDocument();
+  // });
 });

--- a/src/pages/Login/index.stories.tsx
+++ b/src/pages/Login/index.stories.tsx
@@ -17,5 +17,5 @@ BusinessCreation.args = {
 export const AdminCreation = Template.bind({});
 AdminCreation.args = {
   ...BusinessCreation.args,
-  type: 'admin',
+  type: 'businessLogic',
 };

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -76,7 +76,7 @@ const LoginPage = ({ type }: ILoginPage): JSX.Element => {
                 email: data.adminAccount.adminEmail,
                 firebase_id: user.uid,
                 role: data.adminAccount.role,
-                root: true,
+                // root: true,  // TODO: Uncomment when problem is fix in backend
               },
             };
             await fetch('/api/business/createBusiness', {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -43,8 +43,6 @@ const steps: Step[] = [
   },
 ];
 
-// const BASE_URL = process.env.REACT_FETCH_BASE_URL ?? 'localhost:1337';
-
 const LoginPage = ({ type }: ILoginPage): JSX.Element => {
   const navigate = useNavigate();
   let content: React.ReactNode;
@@ -76,7 +74,7 @@ const LoginPage = ({ type }: ILoginPage): JSX.Element => {
                 email: data.adminAccount.adminEmail,
                 firebase_id: user.uid,
                 role: data.adminAccount.role,
-                // root: true,  // TODO: Uncomment when problem is fix in backend
+                root: true,
               },
             };
             await fetch('/api/business/createBusiness', {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -14,7 +14,7 @@ const progress: Progress[] = [
   },
   {
     icon: 'admin_panel_settings',
-    text: 'Root accout',
+    text: 'Root account',
   },
   {
     icon: 'done_all',

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,13 +1,45 @@
 import { useNavigate } from 'react-router-dom';
-import { createUserWithEmailAndPassword } from 'firebase/auth';
 
-import { auth } from '../../firebase';
-import AdminForm, { IFormData as AdminFormData } from './AdminForm';
 import BusinessForm, { IFormData as BusinessFormData } from './BusinessForm';
+import MultiStepForm, { Progress, Step } from '../../features/MultiStepForm';
 
 export declare interface ILoginPage {
-  type: 'business' | 'admin' | 'login'
+  type: 'business' | 'businessLogic' | 'login'
 }
+
+const progress: Progress[] = [
+  {
+    icon: 'feed',
+    text: 'Business profile',
+  },
+  {
+    icon: 'admin_panel_settings',
+    text: 'Root accout',
+  },
+  {
+    icon: 'done_all',
+    text: 'Validation',
+  },
+];
+
+const steps: Step[] = [
+  {
+    stepId: 'profile',
+    caption: "Let's create your business profile",
+    last: false,
+  },
+  {
+    stepId: 'adminAccount',
+    caption: "Let's create your main account",
+    last: false,
+  },
+  {
+    stepId: 'validation',
+    // title: 'Your business is being created',
+    caption: "Let's create your business",
+    last: true,
+  },
+];
 
 const LoginPage = ({ type }: ILoginPage): JSX.Element => {
   const navigate = useNavigate();
@@ -15,6 +47,9 @@ const LoginPage = ({ type }: ILoginPage): JSX.Element => {
   let onSubmit;
 
   switch (type) {
+    case 'businessLogic':
+      content = (<MultiStepForm steps={steps} progress={progress} />);
+      break;
     case 'business':
       onSubmit = async (data: BusinessFormData) => {
         await fetch('/business', {
@@ -36,42 +71,42 @@ const LoginPage = ({ type }: ILoginPage): JSX.Element => {
       };
       content = (<BusinessForm onSubmit={onSubmit}/>);
       break;
-    case 'admin':
-      onSubmit = async (data: AdminFormData) => {
-        const businessId = 1234;
-        createUserWithEmailAndPassword(auth, data.adminEmail, data.adminPassword)
-          .then(async (userCredential) => {
-            // Signed in
-            const user = userCredential.user;
-            const reqData = {
-              firebaseId: user.uid,
-              email: data.adminEmail,
-              name: data.adminName,
-              businessId,
-              root: true, // True only while creating the business
-            };
-            await fetch(`/business/${businessId}/user`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify(reqData),
-            }).then(res => {
-              console.log(res);
-              navigate('/1234/dashboard', {
-                replace: true,
-                relative: 'route',
-              });
-            });
-          })
-          .catch((error) => {
-            const errorCode = error.code;
-            const errorMessage = error.message;
-            console.log(errorCode, errorMessage);
-          });
-      };
-      content = (<AdminForm onSubmit={onSubmit}/>);
-      break;
+    // case 'admin':
+    //   onSubmit = async (data: AdminFormData) => {
+    //     const businessId = 1234;
+    //     createUserWithEmailAndPassword(auth, data.adminEmail, data.adminPassword)
+    //       .then(async (userCredential) => {
+    //         // Signed in
+    //         const user = userCredential.user;
+    //         const reqData = {
+    //           firebaseId: user.uid,
+    //           email: data.adminEmail,
+    //           name: data.adminName,
+    //           businessId,
+    //           root: true, // True only while creating the business
+    //         };
+    //         await fetch(`/business/${businessId}/user`, {
+    //           method: 'POST',
+    //           headers: {
+    //             'Content-Type': 'application/json',
+    //           },
+    //           body: JSON.stringify(reqData),
+    //         }).then(res => {
+    //           console.log(res);
+    //           navigate('/1234/dashboard', {
+    //             replace: true,
+    //             relative: 'route',
+    //           });
+    //         });
+    //       })
+    //       .catch((error) => {
+    //         const errorCode = error.code;
+    //         const errorMessage = error.message;
+    //         console.log(errorCode, errorMessage);
+    //       });
+    //   };
+    //   content = (<AdminForm onSubmit={onSubmit}/>);
+    //   break;
     case 'login':
       content = null;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,11 +11,21 @@ module.exports = {
         'brand-blue': {
           light: '#9FE7F5',
           DEFAULT: '#429EBD',
-          dark: '#O53F5C',
+          'light-dark': '#165B7E',
+          dark: '#053F5C',
         },
       },
       spacing: {
         4.5: '1rem',
+      },
+      lineHeight: {
+        null: '0',
+      },
+      fontFamily: {
+        display: ['Merienda', 'cursive'],
+      },
+      fontSize: {
+        ultra: ['200px', '170px'],
       },
     },
   },


### PR DESCRIPTION
# General info

**Issue number**: Papilio-34

**Task description**: 
The task was to add the profile of the companies
- creation of the profile in business creation process
- Add profile page to dashboard
- Display profile in dashboard page
- Allow update of the different profile information

# Manual Testing
to test the profile creation you have to create your own business: 
1. start the backend
` npm run build && npm start`
2. start the website
`npm start`
3. on the main page add the businessId then click on create business
4. enter the profile information then click next
5. enter the admin root account information then click next
6. click submit
7. using postman visit the following url by entering the businessId you enter in 3 in place of `:businessId`
`http://localhost:1337/api/business/get/:businessId`

# Testing
To run all the unit test, run the following code: 
`npm test`

**Test coverage**:
<img width="575" alt="Screen Shot 2022-11-02 at 8 54 15 PM" src="https://user-images.githubusercontent.com/29782830/199628973-3c576d2e-f6d0-47b4-b922-fd8fac9ccede.png">
<img width="574" alt="Screen Shot 2022-11-02 at 8 54 38 PM" src="https://user-images.githubusercontent.com/29782830/199628997-aaf3455b-dfe1-41ce-85f7-753afeab8bfc.png">

## Notes
- There is no need to worry about the */*.stories.tsx files. They are not needed to make the overall project works.