### PR TITLE
Papilio 67 task

### DIFF
--- a/src/pages/Login/LoginForm/index.spec.tsx
+++ b/src/pages/Login/LoginForm/index.spec.tsx
@@ -9,7 +9,6 @@ import * as constant from './constant';
 test('logic test', async () => {
   const mockonSubmit = jest.fn();
 
-
   render(
     <MemoryRouter>
       <LoginForm onSubmit={mockonSubmit} />
@@ -17,7 +16,6 @@ test('logic test', async () => {
   );
 
   expect(screen.getByText(constant.FORM_HEADING)).toBeInTheDocument();
-  
   userEvent.type(await screen.findByPlaceholderText(constant.INPUT_EMAIL_PLACEHOLDER), 'login@email.com');
   userEvent.type(await screen.findByPlaceholderText(constant.INPUT_PASSWORD_PLACEHOLDER), 'password');
   userEvent.click(await screen.findByText(constant.SUBMIT_BUTTON_TEXT));


### PR DESCRIPTION
# General info
I tried to implement a custom select to give the user a better experience while filling the form. There was some part of the component that was not working properly so I change the component to a pre-build one.

**Issue number**: Papilio-67

**Task description**: 
 - Create Select Input -> Use library select input
 - Add the corresponding test

## Manual Testing

To test the select input you have to create your businessId then visit the profile form

Make sure that you have the appropriate variables in the backend .env file. (Contact me if you don't)
1. start the backend
```npm run build && npm start```
2. start the website
```npm start```
3. on the main page add the businessId then click on create business
4. Play with the select input for Country and Province

##Testing

To run all the unit tests, run the following code: ```npm test```
To make sure that the tests have reach the appropriate level of coverage, run the following code: ```npm run coverage```
