### PR TITLE
PAPILIO-82 Frontend ad tiers added

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Dashboard from './pages/Dashboard';
 import EmployeeDashboard from './pages/Dashboard/Employees';
 import ActivityDashboard from './pages/Dashboard/Activities';
 import ProfileDashboard from './pages/Dashboard/Profile';
+import AdsDashboard from './pages/Dashboard/AdCenter';
 import ErrorPage from './pages/Error';
 import LoginPage from './pages/Login';
 
@@ -36,7 +37,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'ads',
-        element: <div>Ad center</div>,
+        element: <AdsDashboard />,
       },
       {
         path: 'profile',

--- a/src/components/CheckMark/index.tsx
+++ b/src/components/CheckMark/index.tsx
@@ -1,0 +1,7 @@
+const CheckMark = (): JSX.Element => {
+  return (
+    <span className="material-symbols-outlined">task_alt</span>
+  );
+};
+
+export default CheckMark;

--- a/src/features/Ad/index.css
+++ b/src/features/Ad/index.css
@@ -1,0 +1,28 @@
+@tailwind base;
+@tailwind components;
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,600;1,400;1,600&display=swap');
+
+html, body, label {
+  font-family: 'Roboto', sans-serif;
+}
+
+@layer base {
+    .createGrid{
+        @apply flex flex-col grid grid-cols-3 gap-x-4 text-left text-sm xl:text-lg py-4 px-16;
+    }
+}
+
+@layer components {
+    .basic{
+        @apply bg-gradient-to-b from-[#52a89f] via-[#52a89f] to-[#336964] rounded-[50px] h-fit space-y-2 py-8 xl:py-20 px-4 xl:px-10 text-white;
+    }
+
+    .pro{
+        @apply bg-gradient-to-b from-[#f27f0c] via-[#f27f0c] to-[#BC5E00] rounded-[50px] h-fit space-y-2 py-10 xl:py-20 px-4 xl:px-10 text-white;
+    }
+
+    .ultimate{
+        @apply bg-gradient-to-b from-[#053f5c] via-[#053f5c] to-[#002436] rounded-[50px] h-fit space-y-2 py-10 xl:py-20 px-4 xl:px-10 text-white;
+    }
+}

--- a/src/features/Ad/index.tsx
+++ b/src/features/Ad/index.tsx
@@ -1,0 +1,56 @@
+import '../Ad/index.css';
+import CheckMark from '../../components/CheckMark';
+
+const Ad = (): JSX.Element => {
+  return (
+    <div className='createGrid flex flex-col'>
+      <div className='basic'>
+        <div className='text-xl xl:text-4xl font-bold pb-4 xl:pb-12 text-center'>BASIC</div>
+        <div><CheckMark/> Post <b className='font-extrabold text-lg xl:text-2xl'>1</b> new activity per month</div>
+        <div><CheckMark/> Activity validity limit is <b className='font-extrabold text-lg xl:text-2xl'>1</b> month</div>
+        <div><CheckMark/> Access to the Activity Manager to easily see a list of all of our posted activities</div>
+        <div><CheckMark/> Access to Activity Creation Center</div>
+        <div><CheckMark/> Access to Employee Manager to easily access data about your team</div>
+        <div><CheckMark/> Give access to <b className='font-extrabold text-lg xl:text-2xl'>1</b> employee (admin)</div>
+        <div className='text-lg xl:text-3xl font-bold pt-4 xl:pt-16 text-center'>9.99/month</div>
+        <div className='text-center'>
+          <button className="bg-transparent hover:bg-white text-white text-md xl:text-xl text-center font-semibold hover:text-[#336964] py-2 px-4 border border-white hover:border-transparent rounded">
+            SELECT
+          </button>
+        </div>
+      </div>
+      <div className='pro'>
+        <div className='text-xl xl:text-4xl font-bold pb-4 xl:pb-12 text-center'>PRO</div>
+        <div><CheckMark/> Post <b className='font-extrabold text-lg xl:text-2xl'>3</b> new activities per month</div>
+        <div><CheckMark/> Activity validity limit is <b className='font-extrabold text-lg xl:text-2xl'>3</b> months</div>
+        <div><CheckMark/> Access to the Activity Manager to easily see a list of all of our posted activities</div>
+        <div><CheckMark/> Access to Activity Creation Center</div>
+        <div><CheckMark/> Access to Employee Manager to easily access data about your team</div>
+        <div><CheckMark/> Give access to <b className='font-extrabold text-lg xl:text-2xl'>3</b> employees (including admin)</div>
+        <div className='text-lg xl:text-3xl font-bold pt-4 xl:pt-16 text-center'>14.99/month</div>
+        <div className='text-center'>
+          <button className="bg-transparent hover:bg-white text-white text-md xl:text-xl text-center font-semibold hover:text-[#BC5E00] py-2 px-4 border border-white hover:border-transparent rounded">
+            SELECT
+          </button>
+        </div>
+      </div>
+      <div className='ultimate'>
+        <div className='text-xl xl:text-4xl font-bold pb-4 xl:pb-12 text-center'>ULTIMATE</div>
+        <div><CheckMark/> Post <b className='font-extrabold text-md xl:text-xl'>unlimited</b> new activities per month</div>
+        <div><CheckMark/> Activity validity limit is <b className='font-extrabold text-md xl:text-xl'>unlimited</b></div>
+        <div><CheckMark/> Access to the Activity Manager to easily see a list of all of our posted activities</div>
+        <div><CheckMark/> Access to Activity Creation Center</div>
+        <div><CheckMark/> Access to Employee Manager to easily access data about your team</div>
+        <div><CheckMark/> Give access to <b className='font-extrabold text-lg xl:text-2xl'>10</b> employees (including admin)</div>
+        <div className='text-lg xl:text-3xl font-bold pt-4 xl:pt-16 text-center'>19.99/month</div>
+        <div className='text-center'>
+          <button className="bg-transparent hover:bg-white text-white text-md xl:text-xl text-center font-semibold hover:text-[#002436] py-2 px-4 border border-white hover:border-transparent rounded">
+            SELECT
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Ad;

--- a/src/pages/Dashboard/AdCenter/contant.ts
+++ b/src/pages/Dashboard/AdCenter/contant.ts
@@ -1,0 +1,2 @@
+export const HEADER = 'Ad Center';
+export const SUBHEADER = 'Subscribe and manage';

--- a/src/pages/Dashboard/AdCenter/index.tsx
+++ b/src/pages/Dashboard/AdCenter/index.tsx
@@ -3,11 +3,11 @@ import PageHeader from '../../../features/PageHeader';
 import * as constant from './contant';
 
 const Box = (): JSX.Element => (
-    <div className='border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white'>
-      <span className="material-symbols-outlined">expand_more</span>
-      <span className='flex-1'>User</span>
-      <span className="material-symbols-outlined">account_box</span>
-    </div>
+  <div className='border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white'>
+    <span className="material-symbols-outlined">expand_more</span>
+    <span className='flex-1'>User</span>
+    <span className="material-symbols-outlined">account_box</span>
+  </div>
 );
 
 const AdsDashboard = (): JSX.Element => {

--- a/src/pages/Dashboard/AdCenter/index.tsx
+++ b/src/pages/Dashboard/AdCenter/index.tsx
@@ -1,0 +1,30 @@
+import Ad from '../../../features/Ad';
+import PageHeader from '../../../features/PageHeader';
+import * as constant from './contant';
+
+const Box = (): JSX.Element => (
+    <div className='border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white'>
+      <span className="material-symbols-outlined">expand_more</span>
+      <span className='flex-1'>User</span>
+      <span className="material-symbols-outlined">account_box</span>
+    </div>
+);
+
+const AdsDashboard = (): JSX.Element => {
+  return (
+    <div className='flex flex-col h-full'>
+      <PageHeader
+        header={constant.HEADER}
+        subtitle={constant.SUBHEADER}
+        rhs={(
+          <>
+            <Box />
+          </>
+        )}
+      />
+      <Ad/>
+    </div>
+  );
+};
+
+export default AdsDashboard;


### PR DESCRIPTION
## General Information


**Issue number**: Papilio-82


**Task description:**
Frontend for ad tiers was added to the Ad Center section of the business dashboard.

## Manual Testing
To test the validation follow these steps:
1. Login to website using business credentials 
2. Navigate to Ad Center in dashboard
3. View different Ad Tiers


## Testing 
To run all unit tests, run the following code: ```npm test```
To run the coverage, run the following code: ```npm run coverage```


##Notes
- Need to add functionality to the "select" button (i.e. go to purchase page).
- Need to display existing subscription if already a client.
