### PR TITLE
PAPILIO-89-bug: Business creation relative url

### DIFF
--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -128,7 +128,7 @@ const LoginPage = ({ type }: ILoginPage): JSX.Element => {
       onSubmit = async (data: BusinessFormData) => {
         await getBusiness(data.businessId).then((res) => {
           if (res.status === 200) {
-            navigate('admin', {
+            navigate('/admin', {
               replace: true,
               state: { businessId: data.businessId },
             });


### PR DESCRIPTION
## General
During the business creation process, the user must select an id for their business before being lead on the business creation process. Once the user creates the business id, it redirect to the wrong page. It is redirecting to `/signup/admin` when it should redirect to `/admin`.

_Issue number_: Papilio-89

### Task description:
- Change the url from relative to absolute

## Manual Testing
Make sure that you have the appropriate variables in the backend .env file. (Contact me if you don't)

To test the bug fix:

1. start the backend
`npm run build && npm start`
2. start the website
`npm start`
3. On the main page, click on "get started" at the top right of the page
4. Enter a business ID
5. You should be redirected to the business creation forms

## Testing
To run all the unit tests, run the following code: `npm test`
To make sure that the tests have reach the appropriate level of coverage, run the following code: `npm run coverage`