### PR TITLE
PAPILIO-90-task

### DIFF
--- a/src/api/apiLayer.test.tsx
+++ b/src/api/apiLayer.test.tsx
@@ -306,7 +306,7 @@ describe('api test', () => {
       const employees = ['1234'];
       await API.deleteEmployees(employees, businessId);
       expect(global.fetch).toHaveBeenCalledWith(
-        `api/business/${businessId}/removeEmployee/1234`,
+        `/api/business/${businessId}/removeEmployee/1234`,
         {
           method: 'DELETE',
         },

--- a/src/api/apiLayer.test.tsx
+++ b/src/api/apiLayer.test.tsx
@@ -28,11 +28,11 @@ describe('api test', () => {
     ).mockResolvedValue(new Response());
   });
 
-  describe('login related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
+  afterEach(() => {
+    (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
+  });
 
+  describe('login related test', () => {
     it('should send the request to the correct endpoint and format the result', async () => {
       (
         global.fetch as jest.MockedFunction<typeof global.fetch>
@@ -68,20 +68,12 @@ describe('api test', () => {
   });
 
   describe('register related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should do something', async () => {
       await API.register(BUSINESS_ID);
     });
   });
 
   describe('getProfile related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should send the request to the correct endpoint', async () => {
       await API.getProfile(BUSINESS_ID);
 
@@ -93,10 +85,6 @@ describe('api test', () => {
   });
 
   describe('addEmployee related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should send the request to the correct endpoint', async () => {
       const formData = {
         firebaseId: FIREBASE_ID,
@@ -124,10 +112,6 @@ describe('api test', () => {
   });
 
   describe('getEmployees related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should reject with an error when businessId is not present', async () => {
       await API.getEmployees('').catch((e) =>
         expect(e).toEqual(new Error('No business Id', { cause: 1 })),
@@ -179,10 +163,6 @@ describe('api test', () => {
   });
 
   describe('addBusiness related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should send the request to the correct endpoint', async () => {
       const formData = {
         business: {
@@ -214,10 +194,6 @@ describe('api test', () => {
   });
 
   describe('getBusiness related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should send the request to the correct endpoint', async () => {
       await API.getBusiness(BUSINESS_ID);
 
@@ -229,10 +205,6 @@ describe('api test', () => {
   });
 
   describe('getActivities related test', () => {
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
-
     it('should reject with an error when businessId is not present', async () => {
       await API.getActivites('').catch((e) =>
         expect(e).toEqual(new Error('No business Id', { cause: 1 })),
@@ -281,9 +253,6 @@ describe('api test', () => {
 
   describe('addActivity related test', () => {
     let formData: IActivityData;
-    afterEach(() => {
-      (global.fetch as jest.MockedFunction<typeof global.fetch>).mockClear();
-    });
 
     beforeEach(() => {
       formData = {
@@ -327,6 +296,27 @@ describe('api test', () => {
           }),
         },
       );
+    });
+  });
+
+  describe('deleteEmployee', () => {
+    const businessId = 'businessId';
+
+    it('should send the request to the correct endpoint', async () => {
+      const employees = ['1234'];
+      await API.deleteEmployees(employees, businessId);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `api/business/${businessId}/removeEmployee/1234`,
+        {
+          method: 'DELETE',
+        },
+      );
+    });
+
+    it('calls fetch for each employee to delete', async () => {
+      const employees = ['1234', '2345'];
+      await API.deleteEmployees(employees, businessId);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/api/apiLayer.tsx
+++ b/src/api/apiLayer.tsx
@@ -100,7 +100,26 @@ export async function getEmployees(businessId: string): Promise<Response> {
 }
 
 export function updateEmployeeRole(): void {}
-export async function deleteEmployee(employees: string[]): Promise<void> {}
+export async function deleteEmployees(
+  employees: string[],
+  businessId: string,
+): Promise<void> {
+  employees.forEach(async (employee) => {
+    await deleteEmployee(employee, businessId);
+  });
+}
+
+export async function deleteEmployee(
+  employeeId: string,
+  businessId: string,
+): Promise<Response> {
+  return await fetch(
+    `api/business/${businessId}/removeEmployee/${employeeId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+}
 export async function addBusiness(
   data: Interfaces.IBusinessData,
 ): Promise<Response> {

--- a/src/api/apiLayer.tsx
+++ b/src/api/apiLayer.tsx
@@ -100,6 +100,7 @@ export async function getEmployees(businessId: string): Promise<Response> {
 }
 
 export function updateEmployeeRole(): void {}
+export async function deleteEmployee(employees: string[]): Promise<void> {}
 export async function addBusiness(
   data: Interfaces.IBusinessData,
 ): Promise<Response> {

--- a/src/api/apiLayer.tsx
+++ b/src/api/apiLayer.tsx
@@ -114,7 +114,7 @@ export async function deleteEmployee(
   businessId: string,
 ): Promise<Response> {
   return await fetch(
-    `api/business/${businessId}/removeEmployee/${employeeId}`,
+    `/api/business/${businessId}/removeEmployee/${employeeId}`,
     {
       method: 'DELETE',
     },

--- a/src/features/Table/Cell/index.spec.tsx
+++ b/src/features/Table/Cell/index.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import Cell from '.';
+
+const renderCell = (cell: React.ReactNode): JSX.Element => (
+  <table>
+    <tbody>
+      <tr>{cell}</tr>
+    </tbody>
+  </table>
+);
+
+const defaultProps = {
+  value: 'cell',
+};
+
+describe('Row', () => {
+  it('display table body cell has default', () => {
+    render(renderCell(<Cell {...defaultProps} />));
+    expect(screen.getByText('cell', { selector: 'td' }));
+  });
+
+  it('display table header cell when head is true', () => {
+    render(renderCell(<Cell {...defaultProps} head />));
+    expect(screen.getByText('cell', { selector: 'th' }));
+  });
+});

--- a/src/features/Table/Row/index.spec.tsx
+++ b/src/features/Table/Row/index.spec.tsx
@@ -1,0 +1,110 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import Row, { ClickableRow } from '.';
+import Cell from '../Cell';
+
+jest.mock('../Cell', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const oneCell = Array.from('1');
+const tenCells = Array.from('0123456789');
+
+const renderRow = (row: ReactNode): JSX.Element => (
+  <table>
+    <tbody>{row}</tbody>
+  </table>
+);
+
+const rowDefaultProps = {
+  data: [],
+  head: false,
+};
+
+describe('Row', () => {
+  it('displays a table row', () => {
+    render(renderRow(<Row {...rowDefaultProps} />));
+    expect(screen.getByRole('row')).toBeInTheDocument();
+  });
+
+  it('renders a Cell when a single cell information is passed', () => {
+    render(renderRow(<Row {...rowDefaultProps} data={oneCell} />));
+    expect(Cell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: '1',
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('renders 10 cells when 10 cell information are passed', () => {
+    render(renderRow(<Row {...rowDefaultProps} data={tenCells} />));
+    expect(Cell).toHaveBeenCalledTimes(10);
+  });
+
+  it('renders a header Cell when the header is true', () => {
+    render(renderRow(<Row data={oneCell} head />));
+    expect(Cell).toHaveBeenCalledWith(
+      expect.objectContaining({ head: true }),
+      expect.anything(),
+    );
+  });
+
+  it('renders a normal Cell as default', () => {
+    render(renderRow(<Row data={oneCell} />));
+    expect(Cell).toHaveBeenCalledWith(
+      expect.objectContaining({ head: false }),
+      expect.anything(),
+    );
+  });
+});
+
+const clickableRowDefaultProps = {
+  data: [],
+  onClick: () => {},
+};
+
+describe('ClickableRow', () => {
+  it('displays a table row', () => {
+    render(renderRow(<ClickableRow {...clickableRowDefaultProps} />));
+    expect(screen.getByRole('row')).toBeInTheDocument();
+  });
+
+  it('displays a checkbox input to select the row', () => {
+    render(renderRow(<ClickableRow {...clickableRowDefaultProps} />));
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('renders a Cell when a single cell information is passed', () => {
+    render(
+      renderRow(<ClickableRow {...clickableRowDefaultProps} data={oneCell} />),
+    );
+    expect(Cell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: '1',
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('renders 10 cells when 10 cell information are passed', () => {
+    render(
+      renderRow(<ClickableRow {...clickableRowDefaultProps} data={tenCells} />),
+    );
+    expect(Cell).toHaveBeenCalledTimes(10);
+  });
+
+  it('calls onClick when the checkbox is clicked', () => {
+    const mockOnClick = jest.fn();
+    render(
+      renderRow(
+        <ClickableRow {...clickableRowDefaultProps} onClick={mockOnClick} />,
+      ),
+    );
+
+    userEvent.click(screen.getByRole('checkbox'));
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/src/features/Table/Row/index.spec.tsx
+++ b/src/features/Table/Row/index.spec.tsx
@@ -63,6 +63,7 @@ describe('Row', () => {
 
 const clickableRowDefaultProps = {
   data: [],
+  disabled: false,
   onClick: () => {},
 };
 
@@ -106,5 +107,15 @@ describe('ClickableRow', () => {
 
     userEvent.click(screen.getByRole('checkbox'));
     expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('disable the checkbox when disabled is true', () => {
+    const mockOnClick = jest.fn();
+    render(
+      renderRow(<ClickableRow data={oneCell} onClick={mockOnClick} disabled />),
+    );
+
+    userEvent.click(screen.getByRole('checkbox'));
+    expect(mockOnClick).not.toHaveBeenCalled();
   });
 });

--- a/src/features/Table/Row/index.tsx
+++ b/src/features/Table/Row/index.tsx
@@ -3,34 +3,35 @@ import Cell from '../Cell';
 export declare interface RowInterface {
   data: string[];
   head?: boolean;
-  isClickable?: boolean;
-  onClick?: () => void;
 }
-const Row = ({
-  data,
-  head = false,
-  isClickable = false,
-  onClick,
-}: RowInterface): JSX.Element => {
-  const handleOnClick = (): void => {
-    if (onClick != null) {
-      onClick();
-    }
-  };
-
+const Row = ({ data, head = false }: RowInterface): JSX.Element => {
   return (
-    <>
-      <tr className="border-gray-100 border-b last:border-b-0">
-        <td>
-          {isClickable ? (
-            <input type="checkbox" onClick={handleOnClick} />
-          ) : null}
-        </td>
-        {data.map((cell) => (
-          <Cell key={cell} value={cell} head={head} />
-        ))}
-      </tr>
-    </>
+    <tr className="border-gray-100 border-b last:border-b-0">
+      {data.map((cell) => (
+        <Cell key={cell} value={cell} head={head} />
+      ))}
+    </tr>
+  );
+};
+
+export declare interface ClickableRowProps {
+  data: string[];
+  onClick: () => void;
+}
+
+export const ClickableRow = ({
+  data,
+  onClick,
+}: ClickableRowProps): JSX.Element => {
+  return (
+    <tr className="border-gray-100 border-b last:border-b-0">
+      <td>
+        <input type="checkbox" onClick={onClick} />
+      </td>
+      {data.map((cell) => (
+        <Cell key={cell} value={cell} />
+      ))}
+    </tr>
   );
 };
 

--- a/src/features/Table/Row/index.tsx
+++ b/src/features/Table/Row/index.tsx
@@ -16,17 +16,19 @@ const Row = ({ data, head = false }: RowInterface): JSX.Element => {
 
 export declare interface ClickableRowProps {
   data: string[];
+  disabled: boolean;
   onClick: () => void;
 }
 
 export const ClickableRow = ({
   data,
+  disabled,
   onClick,
 }: ClickableRowProps): JSX.Element => {
   return (
     <tr className="border-gray-100 border-b last:border-b-0">
       <td>
-        <input type="checkbox" onClick={onClick} />
+        <input type="checkbox" onClick={onClick} disabled={disabled} />
       </td>
       {data.map((cell) => (
         <Cell key={cell} value={cell} />

--- a/src/features/Table/index.spec.tsx
+++ b/src/features/Table/index.spec.tsx
@@ -122,4 +122,24 @@ describe('Table', () => {
       expect.anything(),
     );
   });
+
+  it('disabled row when id to disabled match row id', () => {
+    const id = oneEmployee[0].id;
+    const mockOnSelect = jest.fn();
+    render(
+      <Table
+        {...defaultProps}
+        employees={oneEmployee}
+        onSelect={mockOnSelect}
+        disabledRowId={id}
+      />,
+    );
+
+    expect(ClickableRow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        disabled: true,
+      }),
+      expect.anything(),
+    );
+  });
 });

--- a/src/features/Table/index.spec.tsx
+++ b/src/features/Table/index.spec.tsx
@@ -14,7 +14,7 @@ const oneEmployee = [
 const fiveEmployees = Array.from('01234', (id) => ({
   id,
   name: 'John Smith',
-  email: 'fake@email.com',
+  email: `fake${id}@email.com`,
   role: 'Admin',
 }));
 
@@ -59,7 +59,16 @@ describe('Table', () => {
 
   it('displays 5 rows in the table body when 5 employees are passed', () => {
     render(<Table {...defaultProps} employees={fiveEmployees} />);
-    expect(Row).toHaveBeenCalledTimes(6); // With 1 header row
+    expect(Row).toHaveBeenLastCalledWith(
+      {
+        data: [
+          fiveEmployees[4].name,
+          fiveEmployees[4].email,
+          fiveEmployees[4].role,
+        ],
+      },
+      expect.anything(),
+    );
   });
 
   it('displays clickable row when onSelect is passed as attribute to table', () => {
@@ -67,13 +76,11 @@ describe('Table', () => {
     render(
       <Table
         {...defaultProps}
-        employees={fiveEmployees}
+        employees={oneEmployee}
         onSelect={mockOnSelect}
       />,
     );
-
-    expect(Row).toHaveBeenCalledTimes(1);
-    expect(ClickableRow).toHaveBeenCalledTimes(5);
+    expect(ClickableRow).toHaveBeenCalled();
   });
 
   it('displays content in header that was passed to the table', () => {
@@ -98,11 +105,21 @@ describe('Table', () => {
         onSelect={mockOnSelect}
       />,
     );
-    expect(ClickableRow).toHaveBeenCalledTimes(1);
+    expect(ClickableRow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [oneEmployee[0].name, oneEmployee[0].email, oneEmployee[0].role],
+      }),
+      expect.anything(),
+    );
   });
 
   it('disabled click on body row when no onSelect function is passed', () => {
     render(<Table {...defaultProps} employees={oneEmployee} />);
-    expect(Row).toHaveBeenCalledTimes(2);
+    expect(Row).toHaveBeenLastCalledWith(
+      {
+        data: [oneEmployee[0].name, oneEmployee[0].email, oneEmployee[0].role],
+      },
+      expect.anything(),
+    );
   });
 });

--- a/src/features/Table/index.spec.tsx
+++ b/src/features/Table/index.spec.tsx
@@ -1,0 +1,108 @@
+import { screen, render } from '@testing-library/react';
+import Table from '.';
+import Row, { ClickableRow } from './Row';
+
+const oneEmployee = [
+  {
+    id: 'firebaseId',
+    name: 'John Smith',
+    email: 'fake@email.com',
+    role: 'Admin',
+  },
+];
+
+const fiveEmployees = Array.from('01234', (id) => ({
+  id,
+  name: 'John Smith',
+  email: 'fake@email.com',
+  role: 'Admin',
+}));
+
+const defaultProps = {
+  employees: [],
+  headerContent: [],
+};
+
+jest.mock('./Row', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  ClickableRow: jest.fn(),
+}));
+
+describe('Table', () => {
+  it('displays a table', () => {
+    render(<Table {...defaultProps} />);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('displays a header row in the header', () => {
+    render(<Table {...defaultProps} />);
+    expect(Row).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        head: true,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('displays row element in the table body', () => {
+    render(<Table {...defaultProps} employees={oneEmployee} />);
+    expect(Row).toHaveBeenNthCalledWith(
+      2,
+      {
+        data: [oneEmployee[0].name, oneEmployee[0].email, oneEmployee[0].role],
+      },
+      expect.anything(),
+    );
+  });
+
+  it('displays 5 rows in the table body when 5 employees are passed', () => {
+    render(<Table {...defaultProps} employees={fiveEmployees} />);
+    expect(Row).toHaveBeenCalledTimes(6); // With 1 header row
+  });
+
+  it('displays clickable row when onSelect is passed as attribute to table', () => {
+    const mockOnSelect = jest.fn();
+    render(
+      <Table
+        {...defaultProps}
+        employees={fiveEmployees}
+        onSelect={mockOnSelect}
+      />,
+    );
+
+    expect(Row).toHaveBeenCalledTimes(1);
+    expect(ClickableRow).toHaveBeenCalledTimes(5);
+  });
+
+  it('displays content in header that was passed to the table', () => {
+    const header = ['Col1', 'Col2', 'Col3'];
+    render(<Table {...defaultProps} headerContent={header} />);
+
+    expect(Row).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: header,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('enabled click on body row when onSelect function is passed', () => {
+    const mockOnSelect = jest.fn();
+    render(
+      <Table
+        {...defaultProps}
+        employees={oneEmployee}
+        onSelect={mockOnSelect}
+      />,
+    );
+    expect(ClickableRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('disabled click on body row when no onSelect function is passed', () => {
+    render(<Table {...defaultProps} employees={oneEmployee} />);
+    expect(Row).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/Table/index.stories.tsx
+++ b/src/features/Table/index.stories.tsx
@@ -8,11 +8,10 @@ export default {
 } as ComponentMeta<typeof Table>;
 
 const Template: ComponentStory<typeof Table> = () => (
-  <div className='h-screen'>
-    <Table employees={[]} onSelect={() => {}} />
+  <div className="h-screen">
+    <Table employees={[]} headerContent={[]} onSelect={() => {}} />
   </div>
 );
 
 export const Primary = Template.bind({});
-Primary.args = {
-};
+Primary.args = {};

--- a/src/features/Table/index.tsx
+++ b/src/features/Table/index.tsx
@@ -11,12 +11,18 @@ export interface Employee {
 interface IProps {
   employees: Employee[];
   headerContent: string[];
+  disabledRowId?: string;
   onSelect?: (employee: Employee) => void;
 }
 
 export const employeeTableHeader = ['Employee name', 'Email', 'Role'];
 
-const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
+const Table = ({
+  employees,
+  headerContent,
+  disabledRowId,
+  onSelect,
+}: IProps): JSX.Element => {
   const [buffer, setBuffer] = useState<string[]>([]);
 
   useEffect(() => {
@@ -44,6 +50,7 @@ const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
         key={`employee-${employee.id}`}
         data={data}
         onClick={() => handleOnClick(employee)}
+        disabled={disabledRowId === employee.id}
       />
     );
   });

--- a/src/features/Table/index.tsx
+++ b/src/features/Table/index.tsx
@@ -27,18 +27,17 @@ const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
     }
   }, [onSelect]);
 
+  const handleOnClick = useCallback(
+    // @ts-expect-error
+    (employee: Employee): void => onSelect(employee),
+    [onSelect],
+  );
+
   const employeeRows = employees.map((employee) => {
     const data = [employee.name, employee.email, employee.role];
     if (onSelect === undefined) {
       return <Row key={`employee-${employee.id}`} data={data} />;
     }
-
-    const handleOnClick = useCallback(
-      (employee: Employee): void => {
-        onSelect(employee);
-      },
-      [onSelect],
-    );
 
     return (
       <ClickableRow
@@ -48,8 +47,6 @@ const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
       />
     );
   });
-
-  console.table(buffer);
 
   return (
     <div className="rounded-sm overflow-hidden border border-gray-100 bg-white">

--- a/src/features/Table/index.tsx
+++ b/src/features/Table/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Row, { ClickableRow } from './Row';
 
 export interface Employee {
@@ -17,6 +17,16 @@ interface IProps {
 export const employeeTableHeader = ['Employee name', 'Email', 'Role'];
 
 const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
+  const [buffer, setBuffer] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (onSelect !== undefined) {
+      setBuffer(['']);
+    } else {
+      setBuffer([]);
+    }
+  }, [onSelect]);
+
   const employeeRows = employees.map((employee) => {
     const data = [employee.name, employee.email, employee.role];
     if (onSelect === undefined) {
@@ -39,11 +49,13 @@ const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
     );
   });
 
+  console.table(buffer);
+
   return (
     <div className="rounded-sm overflow-hidden border border-gray-100 bg-white">
       <table className="table-auto border-collapse w-full">
         <thead className="bg-gray-100">
-          <Row data={headerContent} head />
+          <Row data={[...buffer, ...headerContent]} head />
         </thead>
         <tbody>{employeeRows}</tbody>
       </table>

--- a/src/features/Table/index.tsx
+++ b/src/features/Table/index.tsx
@@ -1,4 +1,5 @@
-import Row from './Row';
+import { useCallback } from 'react';
+import Row, { ClickableRow } from './Row';
 
 export interface Employee {
   id: string;
@@ -9,25 +10,31 @@ export interface Employee {
 
 interface IProps {
   employees: Employee[];
+  headerContent: string[];
   onSelect?: (employee: Employee) => void;
 }
 
-const Table = ({ employees, onSelect }: IProps): JSX.Element => {
-  const isClickable = !(onSelect == null);
+export const employeeTableHeader = ['Employee name', 'Email', 'Role'];
 
-  const handleOnClick = (employee: Employee): void => {
-    if (onSelect != null) {
-      onSelect(employee);
-    }
-  };
-
+const Table = ({ employees, headerContent, onSelect }: IProps): JSX.Element => {
   const employeeRows = employees.map((employee) => {
+    const data = [employee.name, employee.email, employee.role];
+    if (onSelect === undefined) {
+      return <Row key={`employee-${employee.id}`} data={data} />;
+    }
+
+    const handleOnClick = useCallback(
+      (employee: Employee): void => {
+        onSelect(employee);
+      },
+      [onSelect],
+    );
+
     return (
-      <Row
+      <ClickableRow
         key={`employee-${employee.id}`}
-        data={[employee.name, employee.email, employee.role]}
+        data={data}
         onClick={() => handleOnClick(employee)}
-        isClickable={isClickable}
       />
     );
   });
@@ -36,7 +43,7 @@ const Table = ({ employees, onSelect }: IProps): JSX.Element => {
     <div className="rounded-sm overflow-hidden border border-gray-100 bg-white">
       <table className="table-auto border-collapse w-full">
         <thead className="bg-gray-100">
-          <Row data={['Employee name', 'Email', 'Role']} head />
+          <Row data={headerContent} head />
         </thead>
         <tbody>{employeeRows}</tbody>
       </table>

--- a/src/pages/Dashboard/AdCenter/index.spec.tsx
+++ b/src/pages/Dashboard/AdCenter/index.spec.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import AdsDashboard from '.';
+import * as constant from './contant';
+import PageHeader from '../../../features/PageHeader';
+import Ad from '../../../features/Ad';
+
+jest.mock('../../../features/PageHeader', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../features/Ad', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('AdsDashboard', () => {
+  it('display a PageHeader at the top of the page with a header and subtitle', () => {
+    render(<AdsDashboard />);
+    expect(PageHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        header: constant.HEADER,
+        subtitle: constant.SUBHEADER,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('displays the ad information', () => {
+    render(<AdsDashboard />);
+    expect(Ad).toHaveBeenCalled();
+  });
+});

--- a/src/pages/Dashboard/AdCenter/index.tsx
+++ b/src/pages/Dashboard/AdCenter/index.tsx
@@ -2,27 +2,23 @@ import Ad from '../../../features/Ad';
 import PageHeader from '../../../features/PageHeader';
 import * as constant from './contant';
 
-const Box = (): JSX.Element => (
-  <div className='border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white'>
+export const Box = (): JSX.Element => (
+  <div className="border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white">
     <span className="material-symbols-outlined">expand_more</span>
-    <span className='flex-1'>User</span>
+    <span className="flex-1">User</span>
     <span className="material-symbols-outlined">account_box</span>
   </div>
 );
 
 const AdsDashboard = (): JSX.Element => {
   return (
-    <div className='flex flex-col h-full'>
+    <div className="flex flex-col h-full">
       <PageHeader
         header={constant.HEADER}
         subtitle={constant.SUBHEADER}
-        rhs={(
-          <>
-            <Box />
-          </>
-        )}
+        rhs={<Box />}
       />
-      <Ad/>
+      <Ad />
     </div>
   );
 };

--- a/src/pages/Dashboard/Employees/DeleteForm/constant.ts
+++ b/src/pages/Dashboard/Employees/DeleteForm/constant.ts
@@ -1,2 +1,2 @@
-export const FORM_HEADLINE = 'Who is the employee you would like to delete?';
+export const FORM_HEADLINE = 'Which employee would you like to delete?';
 export const BUTTON_TEXT = 'Delete employee';

--- a/src/pages/Dashboard/Employees/DeleteForm/index.spec.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.spec.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable no-import-assign */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import DeleteForm from '.';
 import * as constant from './constant';
 import * as Table from '../../../../features/Table';
+import * as hooks from '../../../../hooks/useEmployee';
 
 const defaultProps = {
   employees: [],
@@ -19,7 +21,32 @@ const oneEmployee = [
   },
 ];
 
+const adminEmployee = [
+  {
+    id: 'firebase-id',
+    name: 'John Doe',
+    email: 'fake@email.com',
+    role: 'Admin',
+  },
+];
+
 describe('Delete Form', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    hooks.useAuth = jest.fn().mockReturnValue({
+      employee: {
+        name: 'John Doe',
+        role: 'Admin',
+        firebaseId: 'firebase-id',
+        businessId: 'businessId',
+      },
+    });
+  });
+
+  afterEach(() => {
+    (hooks.useAuth as jest.MockedFunction<typeof hooks.useAuth>).mockClear();
+  });
+
   it('displays the form headline', () => {
     render(<DeleteForm {...defaultProps} />);
     expect(screen.getByText(constant.FORM_HEADLINE)).toBeInTheDocument();
@@ -67,6 +94,16 @@ describe('Delete Form', () => {
     render(<DeleteForm employees={oneEmployee} onSubmit={mockOnSubmit} />);
 
     userEvent.dblClick(screen.getByRole('checkbox'));
+    userEvent.click(screen.getByText(constant.BUTTON_TEXT));
+
+    expect(mockOnSubmit).toHaveBeenCalledWith([]);
+  });
+
+  it('block admin from deleting themselves', () => {
+    const mockOnSubmit = jest.fn();
+    render(<DeleteForm employees={adminEmployee} onSubmit={mockOnSubmit} />);
+
+    userEvent.click(screen.getByRole('checkbox'));
     userEvent.click(screen.getByText(constant.BUTTON_TEXT));
 
     expect(mockOnSubmit).toHaveBeenCalledWith([]);

--- a/src/pages/Dashboard/Employees/DeleteForm/index.spec.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.spec.tsx
@@ -7,7 +7,7 @@ import * as Table from '../../../../features/Table';
 
 const defaultProps = {
   employees: [],
-  onSubmit: () => {},
+  onSubmit: async () => {},
 };
 
 const oneEmployee = [
@@ -48,7 +48,7 @@ describe('Delete Form', () => {
       expect.objectContaining({
         employees: oneEmployee,
       }),
-      {},
+      expect.anything(),
     );
   });
 

--- a/src/pages/Dashboard/Employees/DeleteForm/index.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.tsx
@@ -5,6 +5,7 @@ import Table, {
   employeeTableHeader,
 } from '../../../../features/Table';
 import { useState } from 'react';
+import { useAuth } from '../../../../hooks/useEmployee';
 export declare interface DeleteFormInterface {
   employees: Employee[];
   onSubmit: (employeeIds: string[]) => Promise<void>;
@@ -14,18 +15,21 @@ const DeleteForm = ({
   employees,
   onSubmit,
 }: DeleteFormInterface): JSX.Element => {
+  const { employee: admin } = useAuth();
   const [employeesIdsToDelete, setEmployeesIdsToDelete] = useState<string[]>(
     [],
   );
 
   const handleToggleEmployeeToDelete = (employee: Employee): void => {
     const employeeId = employee.id;
-    if (employeesIdsToDelete.includes(employeeId)) {
-      setEmployeesIdsToDelete(
-        employeesIdsToDelete.filter((id) => employeeId !== id),
-      );
-    } else {
-      setEmployeesIdsToDelete([...employeesIdsToDelete, employeeId]);
+    if (employeeId !== admin.firebaseId) {
+      if (employeesIdsToDelete.includes(employeeId)) {
+        setEmployeesIdsToDelete(
+          employeesIdsToDelete.filter((id) => employeeId !== id),
+        );
+      } else {
+        setEmployeesIdsToDelete([...employeesIdsToDelete, employeeId]);
+      }
     }
   };
 

--- a/src/pages/Dashboard/Employees/DeleteForm/index.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.tsx
@@ -22,14 +22,12 @@ const DeleteForm = ({
 
   const handleToggleEmployeeToDelete = (employee: Employee): void => {
     const employeeId = employee.id;
-    if (employeeId !== admin.firebaseId) {
-      if (employeesIdsToDelete.includes(employeeId)) {
-        setEmployeesIdsToDelete(
-          employeesIdsToDelete.filter((id) => employeeId !== id),
-        );
-      } else {
-        setEmployeesIdsToDelete([...employeesIdsToDelete, employeeId]);
-      }
+    if (employeesIdsToDelete.includes(employeeId)) {
+      setEmployeesIdsToDelete(
+        employeesIdsToDelete.filter((id) => employeeId !== id),
+      );
+    } else {
+      setEmployeesIdsToDelete([...employeesIdsToDelete, employeeId]);
     }
   };
 
@@ -43,6 +41,7 @@ const DeleteForm = ({
         employees={employees}
         headerContent={employeeTableHeader}
         onSelect={handleToggleEmployeeToDelete}
+        disabledRowId={admin.firebaseId}
       />
       <Button
         text={constant.BUTTON_TEXT}

--- a/src/pages/Dashboard/Employees/DeleteForm/index.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.tsx
@@ -4,7 +4,7 @@ import Table, { Employee } from '../../../../features/Table';
 import { useState } from 'react';
 export declare interface DeleteFormInterface {
   employees: Employee[];
-  onSubmit: (employeeIds: string[]) => void;
+  onSubmit: (employeeIds: string[]) => Promise<void>;
 }
 
 const DeleteForm = ({
@@ -35,7 +35,7 @@ const DeleteForm = ({
       <Table employees={employees} onSelect={handleToggleEmployeeToDelete} />
       <Button
         text={constant.BUTTON_TEXT}
-        onClick={() => onSubmit(employeesIdsToDelete)}
+        onClick={async () => await onSubmit(employeesIdsToDelete)}
       />
     </div>
   );

--- a/src/pages/Dashboard/Employees/DeleteForm/index.tsx
+++ b/src/pages/Dashboard/Employees/DeleteForm/index.tsx
@@ -1,6 +1,9 @@
 import Button from '../../../../components/Button';
 import * as constant from './constant';
-import Table, { Employee } from '../../../../features/Table';
+import Table, {
+  Employee,
+  employeeTableHeader,
+} from '../../../../features/Table';
 import { useState } from 'react';
 export declare interface DeleteFormInterface {
   employees: Employee[];
@@ -32,7 +35,11 @@ const DeleteForm = ({
         {constant.FORM_HEADLINE}
       </h2>
       <br></br>
-      <Table employees={employees} onSelect={handleToggleEmployeeToDelete} />
+      <Table
+        employees={employees}
+        headerContent={employeeTableHeader}
+        onSelect={handleToggleEmployeeToDelete}
+      />
       <Button
         text={constant.BUTTON_TEXT}
         onClick={async () => await onSubmit(employeesIdsToDelete)}

--- a/src/pages/Dashboard/Employees/index.spec.tsx
+++ b/src/pages/Dashboard/Employees/index.spec.tsx
@@ -10,9 +10,17 @@ import { FORM_HEADLINE } from './AddForm/constant';
 import { AuthProvider } from '../../../context/employeeContext';
 import * as API from '../../../api/apiLayer';
 import * as hooks from '../../../hooks/useEmployee';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('firebase/auth');
 jest.mock('firebase/app');
+
+jest.mock('./DeleteForm', () => ({
+  __esModule: true,
+  default: ({ onSubmit }: any) => (
+    <button data-testid="deleteForm" onClick={() => onSubmit([])} />
+  ),
+}));
 
 describe('logic test', () => {
   beforeEach(() => {
@@ -39,12 +47,18 @@ describe('logic test', () => {
   });
 
   afterEach(() => {
-    (API.getEmployees as jest.MockedFunction<typeof API.getEmployees>).mockClear();
+    (
+      API.getEmployees as jest.MockedFunction<typeof API.getEmployees>
+    ).mockClear();
     (hooks.useAuth as jest.MockedFunction<typeof hooks.useAuth>).mockClear();
   });
 
   test('open add employee form test', async () => {
-    render(<AuthProvider><EmployeeDashboard /></AuthProvider>);
+    render(
+      <AuthProvider>
+        <EmployeeDashboard />
+      </AuthProvider>,
+    );
 
     expect(screen.getByRole('table')).toBeInTheDocument();
     userEvent.click(screen.getByText(constant.ADD_EMPLOYEE_BUTTON));
@@ -53,9 +67,15 @@ describe('logic test', () => {
   });
 
   test('when getEmployee throw error returns empty list of employees', async () => {
-    (API.getEmployees as jest.MockedFunction<typeof API.getEmployees>).mockReturnValueOnce(Promise.reject(new Error('error', { cause: 1 })));
+    (
+      API.getEmployees as jest.MockedFunction<typeof API.getEmployees>
+    ).mockReturnValueOnce(Promise.reject(new Error('error', { cause: 1 })));
 
-    render(<AuthProvider><EmployeeDashboard /></AuthProvider>);
+    render(
+      <AuthProvider>
+        <EmployeeDashboard />
+      </AuthProvider>,
+    );
 
     expect(await screen.findByRole('table')).toBeInTheDocument();
     expect(screen.queryByText(/jdoe@email.com/)).not.toBeInTheDocument();
@@ -68,23 +88,87 @@ describe('logic test', () => {
     // @ts-expect-error
     auth.sendSignInLinkToEmail.mockResolvedValue();
 
-    render(<AuthProvider><EmployeeDashboard /></AuthProvider>);
+    render(
+      <AuthProvider>
+        <EmployeeDashboard />
+      </AuthProvider>,
+    );
 
     userEvent.click(screen.getByText(constant.ADD_EMPLOYEE_BUTTON));
-    userEvent.type(await screen.findByRole('textbox', { name: formConstant.INPUT_EMPLOYEE_FIRST_NAME_LABEL }), 'John');
-    userEvent.type(await screen.findByRole('textbox', { name: formConstant.INPUT_EMPLOYEE_LAST_NAME_LABEL }), 'Doe');
-    userEvent.type(await screen.findByRole('textbox', { name: formConstant.INPUT_EMPLOYEE_EMAIL_LABEL }), 'jd@email.com');
-    userEvent.type(await screen.findByRole('textbox', { name: formConstant.INPUT_ROLE_LABEL }), 'Admin');
+    userEvent.type(
+      await screen.findByRole('textbox', {
+        name: formConstant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
+      }),
+      'John',
+    );
+    userEvent.type(
+      await screen.findByRole('textbox', {
+        name: formConstant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
+      }),
+      'Doe',
+    );
+    userEvent.type(
+      await screen.findByRole('textbox', {
+        name: formConstant.INPUT_EMPLOYEE_EMAIL_LABEL,
+      }),
+      'jd@email.com',
+    );
+    userEvent.type(
+      await screen.findByRole('textbox', {
+        name: formConstant.INPUT_ROLE_LABEL,
+      }),
+      'Admin',
+    );
 
     const button = (await screen.findAllByText(formConstant.BUTTON_TEXT)).at(1);
     userEvent.click(button as Element);
 
     expect(await screen.findByRole('table')).toBeInTheDocument();
-    expect(API.addEmployee).toHaveBeenCalledWith(expect.stringContaining(''), expect.objectContaining({
-      email: 'jd@email.com',
-      firstName: 'John',
-      lastName: 'Doe',
-      role: 'Admin',
-    }));
+    expect(API.addEmployee).toHaveBeenCalledWith(
+      expect.stringContaining(''),
+      expect.objectContaining({
+        email: 'jd@email.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        role: 'Admin',
+      }),
+    );
+  });
+
+  it('hides the action button when employee is not an admin', async () => {
+    // @ts-expect-error
+    hooks.useAuth.mockReturnValue({
+      employee: {
+        role: 'Normal',
+      },
+    });
+
+    render(<EmployeeDashboard />);
+
+    expect(await screen.findByText(constant.HEADER)).toBeInTheDocument();
+    expect(
+      screen.queryByText(constant.ADD_EMPLOYEE_BUTTON),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays deleteForm when delete button is clicked', async () => {
+    render(<EmployeeDashboard />);
+
+    userEvent.click(screen.getByText(constant.DELETE_EMPLOYEE_BUTTON));
+
+    expect(await screen.findByTestId('deleteForm')).toBeInTheDocument();
+  });
+
+  it('calls deleteEmployee when clicking delete in DeleteForm', async () => {
+    // @ts-expect-error
+    API.deleteEmployee = jest.fn().mockResolvedValue({});
+
+    render(<EmployeeDashboard />);
+
+    userEvent.click(screen.getByText(constant.DELETE_EMPLOYEE_BUTTON));
+    userEvent.click(screen.getByTestId('deleteForm'));
+
+    expect(API.deleteEmployee).toHaveBeenCalledWith([]);
+    await act(async () => await Promise.resolve());
   });
 });

--- a/src/pages/Dashboard/Employees/index.spec.tsx
+++ b/src/pages/Dashboard/Employees/index.spec.tsx
@@ -27,10 +27,10 @@ describe('logic test', () => {
     // @ts-expect-error
     hooks.useAuth = jest.fn().mockReturnValue({
       employee: {
-        firstName: 'John',
-        lastName: 'Doe',
+        name: 'John Doe',
         role: 'Admin',
         firebaseId: 'firebase-id',
+        businessId: 'businessId',
       },
     });
     // @ts-expect-error
@@ -161,14 +161,14 @@ describe('logic test', () => {
 
   it('calls deleteEmployee when clicking delete in DeleteForm', async () => {
     // @ts-expect-error
-    API.deleteEmployee = jest.fn().mockResolvedValue({});
+    API.deleteEmployees = jest.fn().mockResolvedValue({});
 
     render(<EmployeeDashboard />);
 
     userEvent.click(screen.getByText(constant.DELETE_EMPLOYEE_BUTTON));
     userEvent.click(screen.getByTestId('deleteForm'));
 
-    expect(API.deleteEmployee).toHaveBeenCalledWith([]);
+    expect(API.deleteEmployees).toHaveBeenCalledWith([], 'businessId');
     await act(async () => await Promise.resolve());
   });
 });

--- a/src/pages/Dashboard/Employees/index.tsx
+++ b/src/pages/Dashboard/Employees/index.tsx
@@ -3,7 +3,7 @@ import { sendSignInLinkToEmail } from 'firebase/auth';
 import { useParams } from 'react-router-dom';
 
 import { auth } from '../../../firebase';
-import Table, { Employee } from '../../../features/Table';
+import Table, { Employee, employeeTableHeader } from '../../../features/Table';
 import Button from '../../../components/Button';
 import SearchBar from '../../../features/SearchBar';
 import PageHeader from '../../../features/PageHeader';
@@ -150,7 +150,9 @@ const EmployeeDashboard = (): JSX.Element => {
   } else if (currentSection === Section.Add) {
     currentForm = <AddForm onSubmit={handleEmployeeCreation} />;
   } else {
-    currentForm = <Table employees={employees} />;
+    currentForm = (
+      <Table employees={employees} headerContent={employeeTableHeader} />
+    );
   }
 
   return (

--- a/src/pages/Dashboard/Employees/index.tsx
+++ b/src/pages/Dashboard/Employees/index.tsx
@@ -15,7 +15,7 @@ import { IconNames } from '../../../components/Icon';
 import * as constant from './constant';
 import {
   addEmployee,
-  deleteEmployee,
+  deleteEmployees,
   getEmployees,
 } from '../../../api/apiLayer';
 import { IEmployeeData } from '../../../interfaces';
@@ -71,7 +71,7 @@ const EmployeeDashboard = (): JSX.Element => {
   const handleEmployeeDeletion = async (
     employeeIds: string[],
   ): Promise<void> => {
-    await deleteEmployee(employeeIds).then(async () => {
+    await deleteEmployees(employeeIds, employee.businessId).then(async () => {
       setEmployees(
         employees.filter((employee) => !employeeIds.includes(employee.id)),
       );

--- a/src/pages/Dashboard/Employees/index.tsx
+++ b/src/pages/Dashboard/Employees/index.tsx
@@ -48,7 +48,7 @@ const EmployeeDashboard = (): JSX.Element => {
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [currentSection, setCurrentSection] = useState(Section.Table);
 
-  const onSubmit = async (data: IFormData): Promise<void> => {
+  const handleEmployeeCreation = async (data: IFormData): Promise<void> => {
     const reqData: IEmployeeData = {
       firebaseId: '',
       email: data.employeeEmail,
@@ -68,7 +68,9 @@ const EmployeeDashboard = (): JSX.Element => {
     });
   };
 
-  const onSubmitDelete = async (employeeIds: string[]): Promise<void> => {
+  const handleEmployeeDeletion = async (
+    employeeIds: string[],
+  ): Promise<void> => {
     await deleteEmployee(employeeIds).then(async () => {
       setEmployees(
         employees.filter((employee) => !employeeIds.includes(employee.id)),
@@ -143,10 +145,10 @@ const EmployeeDashboard = (): JSX.Element => {
   let currentForm = null;
   if (currentSection === Section.Delete) {
     currentForm = (
-      <DeleteForm onSubmit={onSubmitDelete} employees={employees} />
+      <DeleteForm onSubmit={handleEmployeeDeletion} employees={employees} />
     );
   } else if (currentSection === Section.Add) {
-    currentForm = <AddForm onSubmit={onSubmit} />;
+    currentForm = <AddForm onSubmit={handleEmployeeCreation} />;
   } else {
     currentForm = <Table employees={employees} />;
   }

--- a/src/pages/Home/index.spec.tsx
+++ b/src/pages/Home/index.spec.tsx
@@ -1,0 +1,40 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HomePage from '.';
+import Header from '../../features/Header';
+
+const savedLocation = window.location;
+
+jest.mock('../../features/Header', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    delete window.location;
+    // @ts-expect-error
+    window.location = Object.assign(new URL('https://example.org'), {
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    window.location = savedLocation;
+  });
+
+  it('displays a header', () => {
+    render(<HomePage />);
+    expect(Header).toHaveBeenCalled();
+  });
+
+  it('visit to app store when the app store image is clicked', () => {
+    render(<HomePage />);
+    userEvent.click(screen.getAllByRole('img')[1]);
+    expect(window.location.href).toEqual('https://play.google.com/store/apps');
+  });
+});

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -18,10 +18,7 @@ const HomePage = (): JSX.Element => {
           <div className="welcome">
             <div className="flex">
               <h1 className="text-3xl md:text-4xl lg:text-6xl">
-                Welcome to&nbsp;
-              </h1>
-              <h1 className="font-medium text-3xl md:text-4xl lg:text-6xl">
-                Papilio
+                Welcome to <span className="font-medium">Papilio</span>
               </h1>
             </div>
             <h3 className="text-lg md:text-2xl lg:text-4xl">


### PR DESCRIPTION
## General

The current implementation of the website gives the option to our user to select and delete employee from the dashboard. The behaviour is working as it should however, the employee deletion only happens in the frontend. There are no communication with the backend meaning that once the employee is deleted in the frontend, it is not deleted in the database. This leads to an error because once the dashboard is reloaded, the deleted employee will once again reappear.

_Issue number_: Papilio-90

## Task description
- Create delete employee api call
- Add deleteEmployee to deletion process
- Create associated tests
- Refactor to simplify code

## Acceptance test
### An admin can delete another employee 
GIVEN an authenticated employee
AND the employee is an ADMIN
AND the employee is in the Employee Dashboard
WHEN the employee delete an employee
THEN it does not appear on page reload
 
### An admin can’t delete himself 
GIVEN an authenticated employee
AND the employee is an ADMIN
AND the employee is in the Employee Dashboard
WHEN the employee add himself for deletion
THEN the employee is not added

## Manual Test
To test you need to have an employee account with an Admin role. If you don't have one, you can ask me to provide one.

Make sure that you have the appropriate variables in the backend .env file. (Contact me if you don't)

1. start the backend
`npm run build && npm start`
2. start the website
`npm start`
3. On the main page navigate to the login page
4. Insert the admin account information
5. Once logged in, navigate to the Employee page
6. Click on the delete button
7. On the delete page, try to add your account for deletion. You should not be able to do it.
8. Click on another employee and click on delete button
9. Navigate back to the main page of the Employee Dashboard. The employee you deleted should not be present

##Testing
To run all the unit tests, run the following code: `npm test`
To make sure that the tests have reach the appropriate level of coverage, run the following code: `npm run coverage`