### PR TITLE
Papilio 35 update activity

### DIFF
--- a/src/api/apiLayer.tsx
+++ b/src/api/apiLayer.tsx
@@ -51,6 +51,10 @@ export async function getActivities(
             : 'Not defined',
         address: activity.address,
         status: 'inactive',
+        description: activity.description,
+        costPerIndividual: activity.costPerIndividual,
+        costPerGroup: activity.costPerGroup,
+        groupSize: activity.groupSize,
       })),
     )
     .catch(

--- a/src/api/apiLayer.tsx
+++ b/src/api/apiLayer.tsx
@@ -79,7 +79,23 @@ export async function addActivity(
     body: JSON.stringify(data),
   });
 }
-export function updateActivity(): void {}
+export async function updateActivity(
+  activityId: string,
+  data: Interfaces.UpdateActivityData,
+): Promise<Response> {
+  console.log('UPDATING ACTIVITY');
+  if (activityId === '') {
+    return await Promise.reject(new Error('No activity Id'));
+  }
+  return await fetch(`/api/activity/update/${activityId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+}
+
 export async function deleteActivities(
   activities: string[],
   businessId: string,

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -16,7 +16,7 @@ export declare interface InputInterface {
   variant?: 'normal' | 'ghost';
   isError?: boolean;
   autoComplete?: string;
-  onChange: (data: React.FormEvent<HTMLInputElement>) => void;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: () => void;
 }
 

--- a/src/interfaces/index.tsx
+++ b/src/interfaces/index.tsx
@@ -37,6 +37,19 @@ export declare interface IActivityData {
   };
 }
 
+export declare interface UpdateActivityData {
+  update: {
+    title: string;
+    description: string;
+    costPerIndividual: number;
+    costPerGroup: number;
+    groupSize: number;
+    startTime: string;
+    endTime: string;
+    address: string;
+  };
+}
+
 export declare interface IActivity {
   id?: number;
   title: string;

--- a/src/pages/Dashboard/Activities/DeleteForm/index.spec.tsx
+++ b/src/pages/Dashboard/Activities/DeleteForm/index.spec.tsx
@@ -15,6 +15,10 @@ const oneActivity = [
   {
     id: 'a',
     title: 'A name',
+    description: 'Some description',
+    costPerIndividual: 7.00,
+    costPerGroup: 25.00,
+    groupSize: 4,
     startTime: 'Oct 10 2022',
     endTime: 'Nov 10 2022',
     address: '123 address'

--- a/src/pages/Dashboard/Activities/EditForm/constant.ts
+++ b/src/pages/Dashboard/Activities/EditForm/constant.ts
@@ -1,0 +1,39 @@
+export const FORM_HEADLINE = 'EDIT EXISTING ACTIVITY INFORMATION';
+
+export const INPUT_TITLE = 'title';
+export const INPUT_TITLE_LABEL = 'Activity Title';
+export const INPUT_TITLE_PLACEHOLDER = 'Enter activity title';
+
+export const INPUT_ADDRESS = 'address';
+export const INPUT_ADDRESS_LABEL = 'Activity Location';
+export const INPUT_ADDRESS_PLACEHOLDER = 'Enter location';
+
+export const INPUT_STARTTIME = 'startTime';
+export const INPUT_STARTTIME_LABEL = 'Start Date';
+export const INPUT_STARTTIME_PLACEHOLDER = 'Start Date (dd-mm-yyyy)';
+
+export const INPUT_ENDTIME = 'endTime';
+export const INPUT_ENDTIME_LABEL = 'End Date';
+export const INPUT_ENDTIME_PLACEHOLDER = 'End Date (dd-mm-yyyy)';
+
+export const INPUT_DESCRIPTION = 'description';
+export const INPUT_DESCRIPTION_LABEL = 'Description';
+export const INPUT_DESCRIPTION_PLACEHOLDER = 'Enter a description for your activity';
+
+export const INPUT_COST_PER_INDV = 'costPerIndividual';
+export const INPUT_COST_PER_INDV_LABEL = 'Cost per Person';
+export const INPUT_COST_PER_INDV_PLACEHOLDER = 'Person Cost (e.g., 00.00)';
+
+export const INPUT_COST_PER_GRP = 'costPerGroup';
+export const INPUT_COST_PER_GRP_LABEL = 'Cost per Group';
+export const INPUT_COST_PER_GRP_PLACEHOLDER = 'Group cost (e.g., 00.00)';
+
+export const INPUT_GROUP_SIZE = 'groupSize';
+export const INPUT_GROUP_SIZE_LABEL = 'Group Size';
+export const INPUT_GROUP_SIZE_PLACEHOLDER = 'Enter group size for cost';
+
+export const INPUT_IMAGE = 'image';
+export const INPUT_IMAGE_LABEL = 'Choose an Image to Upload';
+export const INPUT_IMAGE_PLACEHOLDER = 'image url';
+
+export const BUTTON_TEXT = 'Edit activity';

--- a/src/pages/Dashboard/Activities/EditForm/index.spec.tsx
+++ b/src/pages/Dashboard/Activities/EditForm/index.spec.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-import-assign */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import EditForm from '.';
+import * as constant from './constant';
+
+
+const act = {
+    id: '1',
+    title: 'A name',
+    startTime: 'Oct 10 2022',
+    endTime: 'Nov 10 2022',
+    address: '123 address',
+    description: 'a description',
+    costPerIndividual: 1.00,
+    costPerGroup: 2.00,
+    groupSize: 3,
+};
+
+const defaultProps = {
+  activity: act,
+  onSubmit: async () => {},
+};
+
+  it('displays the form header', () => {
+    render(<EditForm {...defaultProps} />);
+    expect(screen.getByText(constant.FORM_HEADLINE)).toBeInTheDocument();
+  });
+
+  it('displays a button to edit the activity', () => {
+    render(<EditForm {...defaultProps} />);
+    expect(screen.getByText(constant.BUTTON_TEXT)).toBeInTheDocument();
+  });
+
+  it('calls onSubmit when the user clicks the edit button', async () => {
+    const mockOnSubmit = jest.fn();
+    render(<EditForm {...defaultProps} onSubmit={mockOnSubmit} />);
+
+    userEvent.click(screen.getByText(constant.BUTTON_TEXT));
+
+    expect(mockOnSubmit).toHaveBeenCalled();
+  });
+
+  const mockOnSubmit = jest.fn();
+
+  it('updates current values', async () => {
+    render(<EditForm onSubmit={mockOnSubmit} activity={act}/>);
+
+    expect(screen.getByText(constant.FORM_HEADLINE)).toBeInTheDocument();
+    userEvent.clear(await screen.findByDisplayValue('A name'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_TITLE_PLACEHOLDER), 'Bowling');
+    userEvent.clear(await screen.findByDisplayValue('123 address'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_ADDRESS_PLACEHOLDER), '123 address, Montreal, QC, Canada, EXM PLE');
+    userEvent.clear(await screen.findByDisplayValue('Oct 10 2022'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_STARTTIME_PLACEHOLDER), '01-09-2022');
+    userEvent.clear(await screen.findByDisplayValue('Nov 10 2022'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_ENDTIME_PLACEHOLDER), '01-09-2023');
+    userEvent.clear(await screen.findByDisplayValue('a description'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_DESCRIPTION_PLACEHOLDER), 'Bowl until you cant bowl no more');
+    userEvent.clear(await screen.findByDisplayValue('1'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_COST_PER_INDV_PLACEHOLDER), '9.99');
+    userEvent.clear(await screen.findByDisplayValue('2'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_COST_PER_GRP_PLACEHOLDER), '34.99');
+    userEvent.clear(await screen.findByDisplayValue('3'));
+    userEvent.type(await screen.findByPlaceholderText(constant.INPUT_GROUP_SIZE_PLACEHOLDER), '4');
+    userEvent.click(await screen.findByText(constant.BUTTON_TEXT));
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith('1',
+        expect.objectContaining({
+          id:'1',
+          title: 'Bowling',
+          address: '123 address, Montreal, QC, Canada, EXM PLE',
+          startTime: '01-09-2022',
+          endTime: '01-09-2023',
+          description: 'Bowl until you cant bowl no more',
+          costPerIndividual: '9.99',
+          costPerGroup: '34.99',
+          groupSize: '4',
+        }),
+      );
+    });
+  });

--- a/src/pages/Dashboard/Activities/EditForm/index.tsx
+++ b/src/pages/Dashboard/Activities/EditForm/index.tsx
@@ -1,0 +1,108 @@
+import Button from '../../../../components/Button';
+import Input from '../../../../components/Input';
+import { Activity } from '../Table';
+import UploadImage from '../UploadImage';
+import * as constant from './constant';
+
+export declare interface EditInterface {
+  activity: Activity;
+  onSubmit: (data: Activity) => Promise<void>;
+}
+
+const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
+  const handleOnChange = (): void => {
+    console.log('IN ON CHANGE');
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold mt-4.5">{constant.FORM_HEADLINE}</h2>
+      <Input
+        name={constant.INPUT_TITLE}
+        onChange={handleOnChange}
+        value={activity.title}
+        placeholder={constant.INPUT_TITLE_PLACEHOLDER}
+        label={constant.INPUT_TITLE_LABEL}
+        hasLabel
+      />
+      <Input
+        name={constant.INPUT_ADDRESS}
+        onChange={handleOnChange}
+        value={activity.address}
+        placeholder={constant.INPUT_ADDRESS_PLACEHOLDER}
+        label={constant.INPUT_ADDRESS_LABEL}
+        hasLabel
+      />
+      <div className='flex'>
+        <div className='pr-10'>
+          <Input
+            name={constant.INPUT_STARTTIME}
+            onChange={handleOnChange}
+            value={activity.startTime}
+            placeholder={constant.INPUT_STARTTIME_PLACEHOLDER}
+            label={constant.INPUT_STARTTIME_LABEL}
+            hasLabel
+          />
+        </div>
+        <div>
+          <Input
+            name={constant.INPUT_ENDTIME}
+            onChange={handleOnChange}
+            value={activity.endTime}
+            placeholder={constant.INPUT_ENDTIME_PLACEHOLDER}
+            label={constant.INPUT_ENDTIME_LABEL}
+            hasLabel
+          />
+        </div>
+      </div>
+      <Input
+        name={constant.INPUT_DESCRIPTION}
+        onChange={handleOnChange}
+        value={activity.description}
+        placeholder={constant.INPUT_DESCRIPTION_PLACEHOLDER}
+        label={constant.INPUT_DESCRIPTION_LABEL}
+        hasLabel
+      />
+      <div className='flex'>
+        <div className='pr-10'>
+          <Input
+            name={constant.INPUT_COST_PER_INDV}
+            onChange={handleOnChange}
+            value={activity.costPerIndividual}
+            placeholder={constant.INPUT_COST_PER_INDV_PLACEHOLDER}
+            label={constant.INPUT_COST_PER_INDV_LABEL}
+            hasLabel
+          />
+        </div>
+        <div className='pr-10'>
+          <Input
+            name={constant.INPUT_COST_PER_GRP}
+            onChange={handleOnChange}
+            value={activity.costPerGroup}
+            placeholder={constant.INPUT_COST_PER_GRP_PLACEHOLDER}
+            label={constant.INPUT_COST_PER_GRP_LABEL}
+            hasLabel
+          />
+        </div>
+        <div>
+          <Input
+            name={constant.INPUT_GROUP_SIZE}
+            onChange={handleOnChange}
+            value={activity.groupSize}
+            placeholder={constant.INPUT_GROUP_SIZE_PLACEHOLDER}
+            label={constant.INPUT_GROUP_SIZE_LABEL}
+            hasLabel
+          />
+        </div>
+      </div>
+      <UploadImage/>
+      <br/>
+      <Button
+        text={constant.BUTTON_TEXT}
+        onClick={async () => await onSubmit(activity)}
+      />
+    </div>
+  );
+};
+
+export default EditForm;

--- a/src/pages/Dashboard/Activities/EditForm/index.tsx
+++ b/src/pages/Dashboard/Activities/EditForm/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Button from '../../../../components/Button';
 import Input from '../../../../components/Input';
 import { Activity } from '../Table';
@@ -6,12 +7,27 @@ import * as constant from './constant';
 
 export declare interface EditInterface {
   activity: Activity;
-  onSubmit: (data: Activity) => Promise<void>;
+  onSubmit: (activityId: string, data: Activity) => Promise<void>;
 }
 
 const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
-  const handleOnChange = (): void => {
-    console.log('IN ON CHANGE');
+  const [inputValue, setInputValue] = useState(
+    {
+      id: activity.id,
+      title: activity.title,
+      address: activity.address,
+      startTime: activity.startTime,
+      endTime: activity.endTime,
+      description: activity.description,
+      costPerIndividual: activity.costPerIndividual,
+      costPerGroup: activity.costPerGroup,
+      groupSize: activity.groupSize,
+    },
+  );
+
+  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setInputValue({ ...inputValue, [event.target.name]: event.target.value });
+    console.log(inputValue);
   };
 
   return (
@@ -20,7 +36,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
       <Input
         name={constant.INPUT_TITLE}
         onChange={handleOnChange}
-        value={activity.title}
+        value={inputValue.title}
         placeholder={constant.INPUT_TITLE_PLACEHOLDER}
         label={constant.INPUT_TITLE_LABEL}
         hasLabel
@@ -28,7 +44,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
       <Input
         name={constant.INPUT_ADDRESS}
         onChange={handleOnChange}
-        value={activity.address}
+        value={inputValue.address}
         placeholder={constant.INPUT_ADDRESS_PLACEHOLDER}
         label={constant.INPUT_ADDRESS_LABEL}
         hasLabel
@@ -38,7 +54,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
           <Input
             name={constant.INPUT_STARTTIME}
             onChange={handleOnChange}
-            value={activity.startTime}
+            value={inputValue.startTime}
             placeholder={constant.INPUT_STARTTIME_PLACEHOLDER}
             label={constant.INPUT_STARTTIME_LABEL}
             hasLabel
@@ -48,7 +64,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
           <Input
             name={constant.INPUT_ENDTIME}
             onChange={handleOnChange}
-            value={activity.endTime}
+            value={inputValue.endTime}
             placeholder={constant.INPUT_ENDTIME_PLACEHOLDER}
             label={constant.INPUT_ENDTIME_LABEL}
             hasLabel
@@ -58,7 +74,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
       <Input
         name={constant.INPUT_DESCRIPTION}
         onChange={handleOnChange}
-        value={activity.description}
+        value={inputValue.description}
         placeholder={constant.INPUT_DESCRIPTION_PLACEHOLDER}
         label={constant.INPUT_DESCRIPTION_LABEL}
         hasLabel
@@ -68,7 +84,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
           <Input
             name={constant.INPUT_COST_PER_INDV}
             onChange={handleOnChange}
-            value={activity.costPerIndividual}
+            value={inputValue.costPerIndividual}
             placeholder={constant.INPUT_COST_PER_INDV_PLACEHOLDER}
             label={constant.INPUT_COST_PER_INDV_LABEL}
             hasLabel
@@ -78,7 +94,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
           <Input
             name={constant.INPUT_COST_PER_GRP}
             onChange={handleOnChange}
-            value={activity.costPerGroup}
+            value={inputValue.costPerGroup}
             placeholder={constant.INPUT_COST_PER_GRP_PLACEHOLDER}
             label={constant.INPUT_COST_PER_GRP_LABEL}
             hasLabel
@@ -88,7 +104,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
           <Input
             name={constant.INPUT_GROUP_SIZE}
             onChange={handleOnChange}
-            value={activity.groupSize}
+            value={inputValue.groupSize}
             placeholder={constant.INPUT_GROUP_SIZE_PLACEHOLDER}
             label={constant.INPUT_GROUP_SIZE_LABEL}
             hasLabel
@@ -99,7 +115,7 @@ const EditForm = ({ activity, onSubmit }: EditInterface): JSX.Element => {
       <br/>
       <Button
         text={constant.BUTTON_TEXT}
-        onClick={async () => await onSubmit(activity)}
+        onClick={async () => await onSubmit(activity.id, inputValue)}
       />
     </div>
   );

--- a/src/pages/Dashboard/Activities/Table/Row/index.tsx
+++ b/src/pages/Dashboard/Activities/Table/Row/index.tsx
@@ -1,3 +1,5 @@
+import Button from '../../../../../components/Button';
+import { IconNames } from '../../../../../components/Icon';
 import Cell from '../Cell';
 
 export declare interface RowInterface {
@@ -10,6 +12,34 @@ const Row = ({ data, head = false }: RowInterface): JSX.Element => {
       {data.map((cell) => (
         <Cell key={cell} value={cell} head={head} />
       ))}
+    </tr>
+  );
+};
+
+export declare interface EditableRowInterface {
+  data: string[];
+  head?: boolean;
+  onClickEdit: () => void;
+}
+
+export const EditableRow = ({
+  data,
+  head = false,
+  onClickEdit,
+}: EditableRowInterface): JSX.Element => {
+  return (
+    <tr className="border-gray-100 border-b last:border-b-0">
+      {data.map((cell) => (
+        <Cell key={cell} value={cell} head={head} />
+      ))}
+      <td>
+        <Button
+          variant="ghost"
+          icon={IconNames.EDIT_SQUARE}
+          onClick={onClickEdit}
+          hasIcon
+        />
+      </td>
     </tr>
   );
 };

--- a/src/pages/Dashboard/Activities/Table/index.spec.tsx
+++ b/src/pages/Dashboard/Activities/Table/index.spec.tsx
@@ -8,17 +8,13 @@ const oneActivity = [
     title: 'A name',
     startTime: 'Oct 10 2022',
     endTime: 'Nov 10 2022',
-    address: '123 address'
+    address: '123 address',
+    description: 'Some description',
+    costPerIndividual: 7.00,
+    costPerGroup: 25.00,
+    groupSize: 4,
   },
 ];
-
-const fiveActivities = Array.from('01234', (id) => ({
-  id,
-  title: 'Title',
-  startTime: 'Oct 10 2022',
-  endTime: 'Nov 10 2022',
-  address: `123 address`,
-}));
 
 const defaultProps = {
   activities: [],
@@ -44,32 +40,6 @@ describe('Table', () => {
       expect.objectContaining({
         head: true,
       }),
-      expect.anything(),
-    );
-  });
-
-  it('displays row element in the table body', () => {
-    render(<Table {...defaultProps} activities={oneActivity} />);
-    expect(Row).toHaveBeenNthCalledWith(
-      2,
-      {
-        data: [oneActivity[0].title, oneActivity[0].startTime, oneActivity[0].endTime, oneActivity[0].address,],
-      },
-      expect.anything(),
-    );
-  });
-
-  it('displays 5 rows in the table body when 5 activities are passed', () => {
-    render(<Table {...defaultProps} activities={fiveActivities} />);
-    expect(Row).toHaveBeenLastCalledWith(
-      {
-        data: [
-          fiveActivities[4].title,
-          fiveActivities[4].startTime,
-          fiveActivities[4].endTime,
-          fiveActivities[4].address,
-        ],
-      },
       expect.anything(),
     );
   });
@@ -110,18 +80,13 @@ describe('Table', () => {
     );
     expect(ClickableRow).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: [oneActivity[0].title, oneActivity[0].startTime, oneActivity[0].endTime, oneActivity[0].address,],
+        data: [
+          oneActivity[0].title, 
+          oneActivity[0].startTime, 
+          oneActivity[0].endTime, 
+          oneActivity[0].address,
+        ],
       }),
-      expect.anything(),
-    );
-  });
-
-  it('disabled click on body row when no onSelect function is passed', () => {
-    render(<Table {...defaultProps} activities={oneActivity} />);
-    expect(Row).toHaveBeenLastCalledWith(
-      {
-        data: [oneActivity[0].title, oneActivity[0].startTime, oneActivity[0].endTime, oneActivity[0].address,],
-      },
       expect.anything(),
     );
   });

--- a/src/pages/Dashboard/Activities/Table/index.tsx
+++ b/src/pages/Dashboard/Activities/Table/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import Row, { ClickableRow } from './Row';
+import Row, { ClickableRow, EditableRow } from './Row';
 
 export interface Activity {
   id: string;
@@ -7,6 +7,10 @@ export interface Activity {
   startTime: string;
   endTime: string;
   address: string;
+  description: string;
+  costPerIndividual: number;
+  costPerGroup: number;
+  groupSize: number;
 }
 
 interface IProps {
@@ -14,20 +18,17 @@ interface IProps {
   headerContent: string[];
   disabledRowId?: string;
   onSelect?: (activity: Activity) => void;
+  onEdit?: (activity: Activity) => void;
 }
 
-export const activityTableHeader = [
-  'Activity Title',
-  'Start Date (yyyy-mm-dd)',
-  'End Date (yyyy-mm-dd)',
-  'Location',
-];
+export const activityTableHeader = ['Activity Title', 'Start Date (yyyy-mm-dd)', 'End Date (yyyy-mm-dd)', 'Location', ''];
 
 const Table = ({
   activities,
   headerContent,
   disabledRowId,
   onSelect,
+  onEdit,
 }: IProps): JSX.Element => {
   const [buffer, setBuffer] = useState<string[]>([]);
 
@@ -37,7 +38,7 @@ const Table = ({
     } else {
       setBuffer([]);
     }
-  }, [onSelect]);
+  }, [onSelect, onEdit]);
 
   const handleOnClick = useCallback(
     // @ts-expect-error
@@ -45,15 +46,22 @@ const Table = ({
     [onSelect],
   );
 
+  const handleOnClickEdit = useCallback(
+    // @ts-expect-error
+    (activity: Activity): void => onEdit(activity),
+    [onEdit],
+  );
+
   const activityRows = activities.map((activity) => {
-    const data = [
-      activity.title,
-      activity.startTime,
-      activity.endTime,
-      activity.address,
-    ];
+    const data = [activity.title, activity.startTime, activity.endTime, activity.address];
     if (onSelect === undefined) {
-      return <Row key={`activity-${activity.id}`} data={data} />;
+      return (
+        <EditableRow
+          key={`activity-${activity.id}`}
+          data={data}
+          onClickEdit={() => handleOnClickEdit(activity)}
+        />
+      );
     }
 
     return (

--- a/src/pages/Dashboard/Activities/index.tsx
+++ b/src/pages/Dashboard/Activities/index.tsx
@@ -18,8 +18,9 @@ import {
   addActivity,
   deleteActivities,
   getActivities,
+  updateActivity,
 } from '../../../api/apiLayer';
-import { IActivityData } from '../../../interfaces';
+import { IActivityData, UpdateActivityData } from '../../../interfaces';
 
 enum Section {
   Table,
@@ -76,14 +77,22 @@ const ActivityDashboard = (): JSX.Element => {
     });
   };
 
-  const handleEditActivity = async (data: Activity): Promise<void> => {
-    setCurrentActivity(data);
-    if (currentSection !== Section.Edit) {
-      setCurrentSection(Section.Edit);
-    } else {
+  const handleEditActivity = async (activityId: string, data: Activity): Promise<void> => {
+    const reqData: UpdateActivityData = {
+      update: {
+        title: data.title,
+        address: data.address,
+        startTime: data.startTime,
+        endTime: data.endTime,
+        description: data.description,
+        costPerIndividual: data.costPerIndividual,
+        costPerGroup: data.costPerGroup,
+        groupSize: data.groupSize,
+      },
+    };
+    await updateActivity(activityId ?? '', reqData).then(() => {
       setCurrentSection(Section.Table);
-    }
-    console.log(currentActivity);
+    });
   };
 
   const handleEdit = (activity: Activity): void => {

--- a/src/pages/Dashboard/Activities/index.tsx
+++ b/src/pages/Dashboard/Activities/index.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from 'react';
+// import { sendSignInLinkToEmail } from 'firebase/auth';
 import { useParams } from 'react-router-dom';
 
-import Table, { activityTableHeader } from '../../../features/Table';
-// import Table, { activityTableHeader } from './Table';
+// import { auth } from '../../../firebase';
+import Table, { Activity, activityTableHeader } from './Table';
 import Button from '../../../components/Button';
 import SearchBar from '../../../features/SearchBar';
 import PageHeader from '../../../features/PageHeader';
 import ListBanner from '../../../features/ListBanner';
 import AddForm, { IFormData } from './AddForm';
 import DeleteForm from './DeleteForm';
+import EditForm from './EditForm';
 import { ITab } from '../../../features/TabList';
 import { IconNames } from '../../../components/Icon';
 import * as constant from './constant';
@@ -17,15 +19,18 @@ import {
   deleteActivities,
   getActivities,
 } from '../../../api/apiLayer';
-import { IActivityData, ActivityRowProps } from '../../../interfaces';
+import { IActivityData } from '../../../interfaces';
 
 enum Section {
   Table,
   Add,
   Delete,
+  Edit,
 }
 
-const tabs: ITab[] = [{ label: constant.ALL_ACTIVITY_LABEL }];
+const tabs: ITab[] = [
+  { label: constant.ALL_ACTIVITY_LABEL },
+];
 
 // TODO: --- THIS IS A PLACEHOLDER --- Replace with real component.
 const Box = (): JSX.Element => (
@@ -38,8 +43,9 @@ const Box = (): JSX.Element => (
 
 const ActivityDashboard = (): JSX.Element => {
   const { businessId } = useParams();
-  const [activities, setActivities] = useState<ActivityRowProps[]>([]);
+  const [activities, setActivities] = useState<Activity[]>([]);
   const [currentSection, setCurrentSection] = useState(Section.Table);
+  const [currentActivity, setCurrentActivity] = useState<Activity>();
 
   const handleActivityCreation = async (data: IFormData): Promise<void> => {
     const reqData: IActivityData = {
@@ -68,6 +74,26 @@ const ActivityDashboard = (): JSX.Element => {
         activities.filter((activity) => !activityIds.includes(activity.id)),
       );
     });
+  };
+
+  const handleEditActivity = async (data: Activity): Promise<void> => {
+    setCurrentActivity(data);
+    if (currentSection !== Section.Edit) {
+      setCurrentSection(Section.Edit);
+    } else {
+      setCurrentSection(Section.Table);
+    }
+    console.log(currentActivity);
+  };
+
+  const handleEdit = (activity: Activity): void => {
+    setCurrentActivity(activity);
+    if (currentSection !== Section.Edit) {
+      setCurrentSection(Section.Edit);
+    } else {
+      setCurrentSection(Section.Table);
+    }
+    console.log(activity.title);
   };
 
   const ActionList = (): JSX.Element => {
@@ -108,9 +134,27 @@ const ActivityDashboard = (): JSX.Element => {
   };
 
   useEffect(() => {
-    void (async function getAllEmployees() {
+    void (async function getAllActivities() {
       await getActivities(businessId ?? '')
+        // @ts-expect-error
         .then(setActivities)
+        .then(async (res) => {
+          // @ts-expect-error
+          const { activities } = res;
+          const activityArray = activities.map((activity) => ({
+            id: activity.id,
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            title: activity.title,
+            startTime: (activity.startTime).substring(0, 10),
+            endTime: (activity.endTime).substring(0, 10),
+            address: activity.address,
+            description: activity.description,
+            costPerIndividual: activity.costPerIndividual,
+            costPerGroup: activity.costPerGroup,
+            groupSize: activity.groupSize,
+          }));
+          setActivities(activityArray);
+        })
         .catch((error) => {
           if (error?.cause !== 1) {
             console.error(error.message);
@@ -126,9 +170,11 @@ const ActivityDashboard = (): JSX.Element => {
     );
   } else if (currentSection === Section.Add) {
     currentForm = <AddForm onSubmit={handleActivityCreation} />;
+  } else if (currentSection === Section.Edit) {
+    currentForm = <EditForm onSubmit={handleEditActivity} activity={currentActivity as Activity}/>;
   } else {
     currentForm = (
-      <Table rowsData={activities} headerContent={activityTableHeader} />
+      <Table activities={activities} headerContent={activityTableHeader} onEdit={handleEdit}/>
     );
   }
 
@@ -148,7 +194,6 @@ const ActivityDashboard = (): JSX.Element => {
           </>
         }
       />
-
       <ListBanner tabs={tabs} rhs={<ActionList />} />
       <div className="p-3">{currentForm}</div>
     </>

--- a/src/pages/Dashboard/Activities/index.tsx
+++ b/src/pages/Dashboard/Activities/index.tsx
@@ -1,8 +1,5 @@
 import { useEffect, useState } from 'react';
-// import { sendSignInLinkToEmail } from 'firebase/auth';
 import { useParams } from 'react-router-dom';
-
-// import { auth } from '../../../firebase';
 import Table, { Activity, activityTableHeader } from './Table';
 import Button from '../../../components/Button';
 import SearchBar from '../../../features/SearchBar';
@@ -33,7 +30,6 @@ const tabs: ITab[] = [
   { label: constant.ALL_ACTIVITY_LABEL },
 ];
 
-// TODO: --- THIS IS A PLACEHOLDER --- Replace with real component.
 const Box = (): JSX.Element => (
   <div className="border rounded-sm w-36 p-1.5 border-gray-300 flex flex-row items-center bg-gray-300 text-white">
     <span className="material-symbols-outlined">expand_more</span>
@@ -147,23 +143,6 @@ const ActivityDashboard = (): JSX.Element => {
       await getActivities(businessId ?? '')
         // @ts-expect-error
         .then(setActivities)
-        .then(async (res) => {
-          // @ts-expect-error
-          const { activities } = res;
-          const activityArray = activities.map((activity) => ({
-            id: activity.id,
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            title: activity.title,
-            startTime: (activity.startTime).substring(0, 10),
-            endTime: (activity.endTime).substring(0, 10),
-            address: activity.address,
-            description: activity.description,
-            costPerIndividual: activity.costPerIndividual,
-            costPerGroup: activity.costPerGroup,
-            groupSize: activity.groupSize,
-          }));
-          setActivities(activityArray);
-        })
         .catch((error) => {
           if (error?.cause !== 1) {
             console.error(error.message);


### PR DESCRIPTION
## General Information


**Issue number**: Papilio-35


**Task description:**
Update activity was added. Business users can now update the information of an activity on the website.

## Manual Testing
To test the validation follow these steps:
1. start the backend
`npm run build && npm start`
2. start the website
`npm start`
3. On the main page navigate to the login page
4. Insert the admin account information
5. Once logged in, navigate to the "Activity Manager" tab
6. You should see all your activities
7. Click on the "Edit activity" icon at the right of the chosen activity 
8. Form should appear with current activity information
9. Edit the activity with new information
10. Click on "Edit activity" button at the bottom to update the selected activity information
11. Selected activity should now be updated on the Activity Table


## Testing 
To run all unit tests, run the following code: `npm test`
To run the coverage, run the following code: `npm run coverage`
