### PR TITLE
PAPILIO-108-task

### DIFF
--- a/src/pages/Dashboard/Employees/AddForm/constant.ts
+++ b/src/pages/Dashboard/Employees/AddForm/constant.ts
@@ -12,4 +12,7 @@ export const INPUT_EMPLOYEE_EMAIL_PLACEHOLDER = 'Enter employee email';
 export const INPUT_ROLE = 'role';
 export const INPUT_ROLE_LABEL = 'Employee role';
 export const INPUT_ROLE_PLACEHOLDER = 'Enter employee role';
+export const INPUT_EMPLOYEE_PASSWORD = 'employeePassword';
+export const INPUT_EMPLOYEE_PASSWORD_LABEL = 'Employee password';
+export const INPUT_EMPLOYEE_PASSWORD_PLACEHOLDER = 'Enter employee password';
 export const BUTTON_TEXT = 'Add employee';

--- a/src/pages/Dashboard/Employees/AddForm/index.spec.tsx
+++ b/src/pages/Dashboard/Employees/AddForm/index.spec.tsx
@@ -18,7 +18,7 @@ const fillOtherInputs = (component: null | HTMLElement = null): void =>
     .getAllByRole('textbox')
     .filter((textbox) => textbox !== component)
     .forEach((textbox) => {
-      act(() => userEvent.type(textbox, 'as'));
+      act(() => userEvent.type(textbox, 'as@c.co'));
     });
 
 describe('Employee AddForm', () => {
@@ -91,10 +91,10 @@ describe('Employee AddForm', () => {
   const itSubmitsFieldValueWhenSubmitting = (
     name: string,
     field: string,
+    value: string = 'value',
   ): void =>
     it(`submits ${field} value when submitting`, async () => {
       const mockOnSubmit = jest.fn();
-      const value = 'value';
       render(<AddForm onSubmit={mockOnSubmit} />);
 
       act(() => userEvent.type(screen.getByRole('textbox', { name }), value));
@@ -114,10 +114,12 @@ describe('Employee AddForm', () => {
       );
     });
 
-  const itDisplaysNoErrorMessageWhenNoError = (name: string): void =>
+  const itDisplaysNoErrorMessageWhenNoError = (
+    name: string,
+    value: string = 'value',
+  ): void =>
     it('display no error message when there are no error', async () => {
       const mockOnSubmit = jest.fn();
-      const value = 'value';
       render(<AddForm onSubmit={mockOnSubmit} />);
 
       act(() => userEvent.type(screen.getByRole('textbox', { name }), value));
@@ -135,8 +137,69 @@ describe('Employee AddForm', () => {
       );
     });
 
-  const itDisplaysAnErrorWhenFieldIsTooShort = (): void =>
+  const itDisplaysAnErrorWhenFieldIsTooShort = (name: string): void =>
     it('displays an error message when the first name is too short', async () => {
+      const mockOnSubmit = jest.fn();
+      const value = 'v';
+      render(<AddForm onSubmit={mockOnSubmit} />);
+
+      act(() => userEvent.type(screen.getByRole('textbox', { name }), value));
+      act(() =>
+        userEvent.click(
+          screen.getByRole('button', { name: constant.BUTTON_TEXT }),
+        ),
+      );
+
+      await waitFor(async () =>
+        expect(
+          getErrorSpan(await screen.findByRole('textbox', { name })),
+        ).not.toBeEmptyDOMElement(),
+      );
+    });
+
+  describe('firstName', () => {
+    itDisplaysATextBox(constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL);
+    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL);
+    itSubmitsFieldValueWhenSubmitting(
+      constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
+      'employeeFirstName',
+    );
+    itDisplaysNoErrorMessageWhenNoError(
+      constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
+    );
+    itDisplaysAnErrorWhenFieldIsTooShort(
+      constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
+    );
+  });
+
+  describe('lastName', () => {
+    itDisplaysATextBox(constant.INPUT_EMPLOYEE_LAST_NAME_LABEL);
+    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_LAST_NAME_LABEL);
+    itSubmitsFieldValueWhenSubmitting(
+      constant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
+      'employeeLastName',
+    );
+    itDisplaysNoErrorMessageWhenNoError(
+      constant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
+    );
+    itDisplaysAnErrorWhenFieldIsTooShort(
+      constant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
+    );
+  });
+
+  describe('email', () => {
+    itDisplaysATextBox(constant.INPUT_EMPLOYEE_EMAIL_LABEL);
+    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_EMAIL_LABEL);
+    itSubmitsFieldValueWhenSubmitting(
+      constant.INPUT_EMPLOYEE_EMAIL_LABEL,
+      'employeeEmail',
+      'v@email.com',
+    );
+    itDisplaysNoErrorMessageWhenNoError(
+      constant.INPUT_EMPLOYEE_EMAIL_LABEL,
+      'v@email.com',
+    );
+    it('display an error when email is not an email', async () => {
       const mockOnSubmit = jest.fn();
       const value = 'v';
       render(<AddForm onSubmit={mockOnSubmit} />);
@@ -144,7 +207,7 @@ describe('Employee AddForm', () => {
       act(() =>
         userEvent.type(
           screen.getByRole('textbox', {
-            name: constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
+            name: constant.INPUT_EMPLOYEE_EMAIL_LABEL,
           }),
           value,
         ),
@@ -165,40 +228,16 @@ describe('Employee AddForm', () => {
         ).not.toBeEmptyDOMElement(),
       );
     });
-
-  describe('firstName', () => {
-    itDisplaysATextBox(constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL);
-    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL);
-    itSubmitsFieldValueWhenSubmitting(
-      constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
-      'employeeFirstName',
-    );
-    itDisplaysNoErrorMessageWhenNoError(
-      constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL,
-    );
-    itDisplaysAnErrorWhenFieldIsTooShort();
   });
 
-  describe('lastName', () => {
-    itDisplaysATextBox(constant.INPUT_EMPLOYEE_LAST_NAME_LABEL);
-    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_LAST_NAME_LABEL);
+  describe('password', () => {
+    itDisplaysATextBox(constant.INPUT_EMPLOYEE_PASSWORD_LABEL);
+    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_PASSWORD_LABEL);
     itSubmitsFieldValueWhenSubmitting(
-      constant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
-      'employeeLastName',
+      constant.INPUT_EMPLOYEE_PASSWORD_LABEL,
+      'employeePassword',
     );
-    itDisplaysNoErrorMessageWhenNoError(
-      constant.INPUT_EMPLOYEE_LAST_NAME_LABEL,
-    );
-  });
-
-  describe('email', () => {
-    itDisplaysATextBox(constant.INPUT_EMPLOYEE_EMAIL_LABEL);
-    itSavesFieldWhenTypeIntoTextBox(constant.INPUT_EMPLOYEE_EMAIL_LABEL);
-    itSubmitsFieldValueWhenSubmitting(
-      constant.INPUT_EMPLOYEE_EMAIL_LABEL,
-      'employeeEmail',
-    );
-    itDisplaysNoErrorMessageWhenNoError(constant.INPUT_EMPLOYEE_EMAIL_LABEL);
+    itDisplaysNoErrorMessageWhenNoError(constant.INPUT_EMPLOYEE_PASSWORD_LABEL);
   });
 
   describe('role', () => {

--- a/src/pages/Dashboard/Employees/AddForm/index.tsx
+++ b/src/pages/Dashboard/Employees/AddForm/index.tsx
@@ -1,4 +1,5 @@
 import Button from '../../../../components/Button';
+import ErrorMessage from '../../../../components/ErrorMessage';
 import Input from '../../../../components/Input';
 import useFormData from '../../../../hooks/useFormData';
 import * as constant from './constant';
@@ -11,6 +12,7 @@ export declare interface IFormData {
   employeeFirstName: string;
   employeeLastName: string;
   employeeEmail: string;
+  employeePassword: string;
   role: string;
 }
 
@@ -18,6 +20,7 @@ const initialState: IFormData = {
   employeeFirstName: '',
   employeeLastName: '',
   employeeEmail: '',
+  employeePassword: '',
   role: '',
 };
 
@@ -33,11 +36,12 @@ const AddForm = ({ onSubmit }: AddFormInterface): JSX.Element => {
       <h2 className="text-2xl font-semibold mt-4.5">
         {constant.FORM_HEADLINE}
       </h2>
+      <ErrorMessage isError={!!error.general} message={error.general} />
       <div>
         <Input
           {...register(constant.INPUT_EMPLOYEE_FIRST_NAME, {
             required: false,
-            pattern: /.{2,}/,
+            minLength: 2,
           })}
           placeholder={constant.INPUT_EMPLOYEE_FIRST_NAME_PLACEHOLDER}
           label={constant.INPUT_EMPLOYEE_FIRST_NAME_LABEL}
@@ -52,7 +56,7 @@ const AddForm = ({ onSubmit }: AddFormInterface): JSX.Element => {
         <Input
           {...register(constant.INPUT_EMPLOYEE_LAST_NAME, {
             required: false,
-            pattern: /.{2,}/,
+            minLength: 2,
           })}
           placeholder={constant.INPUT_EMPLOYEE_LAST_NAME_PLACEHOLDER}
           label={constant.INPUT_EMPLOYEE_LAST_NAME_LABEL}
@@ -66,8 +70,9 @@ const AddForm = ({ onSubmit }: AddFormInterface): JSX.Element => {
       <div>
         <Input
           {...register(constant.INPUT_EMPLOYEE_EMAIL, {
-            required: false,
-            pattern: /.+/,
+            required: true,
+            // eslint-disable-next-line no-useless-escape
+            pattern: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
           })}
           placeholder={constant.INPUT_EMPLOYEE_EMAIL_PLACEHOLDER}
           label={constant.INPUT_EMPLOYEE_EMAIL_LABEL}
@@ -80,7 +85,21 @@ const AddForm = ({ onSubmit }: AddFormInterface): JSX.Element => {
       </div>
       <div>
         <Input
-          {...register(constant.INPUT_ROLE, { required: false, pattern: /.*/ })}
+          {...register(constant.INPUT_EMPLOYEE_PASSWORD, {
+            required: true,
+          })}
+          placeholder={constant.INPUT_EMPLOYEE_PASSWORD_PLACEHOLDER}
+          label={constant.INPUT_EMPLOYEE_PASSWORD_LABEL}
+          hasLabel
+        />
+        <span className="error">
+          {error[constant.INPUT_EMPLOYEE_PASSWORD] &&
+            error[constant.INPUT_EMPLOYEE_PASSWORD]}
+        </span>
+      </div>
+      <div>
+        <Input
+          {...register(constant.INPUT_ROLE, { required: true })}
           placeholder={constant.INPUT_ROLE_PLACEHOLDER}
           label={constant.INPUT_ROLE_LABEL}
           hasLabel


### PR DESCRIPTION
## General

The add employee flows does not account for already created firebase user. The backend requires a user to have a firebase_id when being inserted in our database. To make sure we work with the backend, we will rewrite the flow to have the correct information.

We will provide all the information about the employee in the company dashboard. Then the employee account will be created in firebase and the credentials will then be passed towards the backend with the information we require.

_Issue number_: Papilio-108

## Task description
- Rewrite employee add form logic for better error handling
- add password field for employee creation
- rework employee creation request flow
- write the corresponding test

## Manual Test
Make sure that you have the appropriate variables in the backend .env file. (Contact me if you don't)

1. start the backend (Would work best with Papilio-108-task branch in backend 🫤)
`npm run build && npm start`
2. Start the website
`npm start`
3. log in the dashboard
4. visit the employee page
5. Click on the add employee button
6. enter the information
7. You can leave some of the data empty to test error handling
8. With all the correct information, create an employee
9. The employee should appear in the employee table

## Testing
To run all the unit tests, run the following code: `npm test`
To make sure that the tests have reach the appropriate level of coverage, run the following code: `npm run coverage`